### PR TITLE
[codex] Include safe-area metadata in inspection tools

### DIFF
--- a/Android/appreveal/src/main/kotlin/com/appreveal/elements/ElementInfo.kt
+++ b/Android/appreveal/src/main/kotlin/com/appreveal/elements/ElementInfo.kt
@@ -36,6 +36,8 @@ data class ElementInfo(
     val visible: Boolean,
     val tappable: Boolean,
     val frame: ElementFrame,
+    val safeAreaInsets: ElementInsets,
+    val safeAreaLayoutGuideFrame: ElementFrame,
     val containerId: String?,
     val actions: List<String>,
     /** How the id was derived: "explicit", "text", "semantics", "derived" */
@@ -46,5 +48,12 @@ data class ElementInfo(
         val y: Double,
         val width: Double,
         val height: Double,
+    )
+
+    data class ElementInsets(
+        val top: Double,
+        val leading: Double,
+        val bottom: Double,
+        val trailing: Double,
     )
 }

--- a/Android/appreveal/src/main/kotlin/com/appreveal/elements/ElementInventory.kt
+++ b/Android/appreveal/src/main/kotlin/com/appreveal/elements/ElementInventory.kt
@@ -10,6 +10,9 @@ import android.widget.ScrollView
 import android.widget.SeekBar
 import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.widget.NestedScrollView
 import androidx.recyclerview.widget.RecyclerView
 import com.appreveal.R
@@ -17,6 +20,8 @@ import com.appreveal.screen.ScreenResolver
 import com.appreveal.shared.MainThreadExecutor
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.materialswitch.MaterialSwitch
+import kotlin.math.max
+import kotlin.math.min
 
 /**
  * Enumerates visible interactive elements from the Android view hierarchy.
@@ -225,6 +230,8 @@ internal object ElementInventory {
 
         val location = IntArray(2)
         view.getLocationOnScreen(location)
+        val frame = frameFor(view, location)
+        val systemInsets = systemSafeAreaInsets(view)
 
         return ElementInfo(
             id = id,
@@ -234,13 +241,9 @@ internal object ElementInventory {
             enabled = view.isEnabled && (view.isClickable || view.isFocusable || view is EditText),
             visible = view.visibility == View.VISIBLE && view.alpha > 0f,
             tappable = view.isClickable || view.hasOnClickListeners(),
-            frame =
-                ElementInfo.ElementFrame(
-                    x = location[0].toDouble(),
-                    y = location[1].toDouble(),
-                    width = view.width.toDouble(),
-                    height = view.height.toDouble(),
-                ),
+            frame = frame,
+            safeAreaInsets = safeAreaInsets(view, systemInsets),
+            safeAreaLayoutGuideFrame = safeAreaLayoutGuideFrame(frame, systemInsets),
             containerId = containerId,
             actions = availableActions(view),
             idSource = idSource,
@@ -417,11 +420,22 @@ internal object ElementInventory {
 
         val location = IntArray(2)
         view.getLocationOnScreen(location)
+        val frame = frameFor(view, location)
+        val systemInsets = systemSafeAreaInsets(view)
+        val safeAreaInsets = safeAreaInsets(view, systemInsets)
 
         val node =
             mutableMapOf<String, Any>(
                 "class" to view.javaClass.simpleName,
                 "frame" to "${location[0]},${location[1]},${view.width},${view.height}",
+                "safeAreaInsets" to
+                    mapOf(
+                        "top" to safeAreaInsets.top,
+                        "leading" to safeAreaInsets.leading,
+                        "bottom" to safeAreaInsets.bottom,
+                        "trailing" to safeAreaInsets.trailing,
+                    ),
+                "safeAreaLayoutGuideFrame" to safeAreaLayoutGuideFrameMap(frame, systemInsets),
                 "hidden" to (view.visibility != View.VISIBLE),
                 "alpha" to view.alpha,
                 "userInteraction" to (view.isClickable || view.isFocusable),
@@ -487,6 +501,80 @@ internal object ElementInventory {
             }
         }
         return result
+    }
+
+    private fun frameFor(
+        view: View,
+        location: IntArray,
+    ): ElementInfo.ElementFrame =
+        ElementInfo.ElementFrame(
+            x = location[0].toDouble(),
+            y = location[1].toDouble(),
+            width = view.width.toDouble(),
+            height = view.height.toDouble(),
+        )
+
+    private fun systemSafeAreaInsets(view: View): Insets =
+        ViewCompat.getRootWindowInsets(view)
+            ?.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
+            ?: Insets.NONE
+
+    private fun safeAreaInsets(
+        view: View,
+        systemInsets: Insets,
+    ): ElementInfo.ElementInsets {
+        val isRightToLeft = ViewCompat.getLayoutDirection(view) == ViewCompat.LAYOUT_DIRECTION_RTL
+        return ElementInfo.ElementInsets(
+            top = systemInsets.top.toDouble(),
+            leading = if (isRightToLeft) systemInsets.right.toDouble() else systemInsets.left.toDouble(),
+            bottom = systemInsets.bottom.toDouble(),
+            trailing = if (isRightToLeft) systemInsets.left.toDouble() else systemInsets.right.toDouble(),
+        )
+    }
+
+    private fun safeAreaLayoutGuideFrame(
+        frame: ElementInfo.ElementFrame,
+        systemInsets: Insets,
+    ): ElementInfo.ElementFrame {
+        val decorView = ScreenResolver.currentActivity?.window?.decorView ?: return frame
+        val decorLocation = IntArray(2)
+        decorView.getLocationOnScreen(decorLocation)
+
+        val safeLeft = decorLocation[0].toDouble() + systemInsets.left
+        val safeTop = decorLocation[1].toDouble() + systemInsets.top
+        val safeRight = decorLocation[0].toDouble() + decorView.width - systemInsets.right
+        val safeBottom = decorLocation[1].toDouble() + decorView.height - systemInsets.bottom
+
+        val x = max(frame.x, safeLeft)
+        val y = max(frame.y, safeTop)
+        val right = min(frame.x + frame.width, safeRight)
+        val bottom = min(frame.y + frame.height, safeBottom)
+
+        return ElementInfo.ElementFrame(
+            x = x,
+            y = y,
+            width = max(0.0, right - x),
+            height = max(0.0, bottom - y),
+        )
+    }
+
+    private fun safeAreaLayoutGuideFrameMap(
+        frame: ElementInfo.ElementFrame,
+        systemInsets: Insets,
+    ): Map<String, Double> {
+        val decorView = ScreenResolver.currentActivity?.window?.decorView
+        val safeFrame =
+            if (decorView == null) {
+                frame
+            } else {
+                safeAreaLayoutGuideFrame(frame, systemInsets)
+            }
+        return mapOf(
+            "x" to safeFrame.x,
+            "y" to safeFrame.y,
+            "width" to safeFrame.width,
+            "height" to safeFrame.height,
+        )
     }
 
     private fun findView(

--- a/Android/appreveal/src/main/kotlin/com/appreveal/mcpserver/MCPTools.kt
+++ b/Android/appreveal/src/main/kotlin/com/appreveal/mcpserver/MCPTools.kt
@@ -67,6 +67,24 @@ internal fun registerBuiltInTools() {
                             addProperty("visible", if (el.visible) "true" else "false")
                             addProperty("tappable", if (el.tappable) "true" else "false")
                             addProperty("frame", "${el.frame.x.toInt()},${el.frame.y.toInt()},${el.frame.width.toInt()},${el.frame.height.toInt()}")
+                            add(
+                                "safeAreaInsets",
+                                JsonObject().apply {
+                                    addProperty("top", el.safeAreaInsets.top)
+                                    addProperty("leading", el.safeAreaInsets.leading)
+                                    addProperty("bottom", el.safeAreaInsets.bottom)
+                                    addProperty("trailing", el.safeAreaInsets.trailing)
+                                },
+                            )
+                            add(
+                                "safeAreaLayoutGuideFrame",
+                                JsonObject().apply {
+                                    addProperty("x", el.safeAreaLayoutGuideFrame.x)
+                                    addProperty("y", el.safeAreaLayoutGuideFrame.y)
+                                    addProperty("width", el.safeAreaLayoutGuideFrame.width)
+                                    addProperty("height", el.safeAreaLayoutGuideFrame.height)
+                                },
+                            )
                             addProperty("actions", el.actions.joinToString(","))
                             addProperty("idSource", el.idSource)
                         },

--- a/Android/appreveal/src/main/kotlin/com/appreveal/screenshot/ScreenshotCapture.kt
+++ b/Android/appreveal/src/main/kotlin/com/appreveal/screenshot/ScreenshotCapture.kt
@@ -5,6 +5,7 @@ import android.os.Handler
 import android.os.Looper
 import android.util.Base64
 import android.view.PixelCopy
+import androidx.core.view.drawToBitmap
 import com.appreveal.elements.ElementInventory
 import com.appreveal.screen.ScreenResolver
 import com.appreveal.shared.MainThreadExecutor

--- a/Flutter/appreveal/lib/src/elements/element_inventory.dart
+++ b/Flutter/appreveal/lib/src/elements/element_inventory.dart
@@ -1,5 +1,7 @@
 // Flutter widget tree inspection — element listing and full tree dump.
 
+import 'dart:math' as math;
+
 import 'package:flutter/material.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
@@ -107,6 +109,12 @@ class ElementInventory {
 
   /// Get frame string "x,y,width,height" for an element's render box.
   static String? getFrame(Element element) {
+    final rect = getFrameRect(element);
+    if (rect == null) return null;
+    return '${rect.left.round()},${rect.top.round()},${rect.width.round()},${rect.height.round()}';
+  }
+
+  static Rect? getFrameRect(Element element) {
     try {
       final renderObject = element.renderObject;
       if (renderObject is! RenderBox) return null;
@@ -114,10 +122,68 @@ class ElementInventory {
       final offset = renderObject.localToGlobal(Offset.zero);
       final size = renderObject.size;
       if (size.isEmpty) return null;
-      return '${offset.dx.round()},${offset.dy.round()},${size.width.round()},${size.height.round()}';
+      return offset & size;
     } catch (_) {
       return null;
     }
+  }
+
+  static Map<String, double> getSafeAreaInsets(Element element) {
+    final mediaQuery = MediaQuery.maybeOf(element);
+    if (mediaQuery == null) {
+      return {
+        'top': 0,
+        'leading': 0,
+        'bottom': 0,
+        'trailing': 0,
+      };
+    }
+
+    final textDirection = Directionality.maybeOf(element) ?? TextDirection.ltr;
+    final padding = mediaQuery.padding;
+    final isRtl = textDirection == TextDirection.rtl;
+
+    return {
+      'top': padding.top,
+      'leading': isRtl ? padding.right : padding.left,
+      'bottom': padding.bottom,
+      'trailing': isRtl ? padding.left : padding.right,
+    };
+  }
+
+  static Map<String, double>? getSafeAreaLayoutGuideFrame(Element element) {
+    final frameRect = getFrameRect(element);
+    if (frameRect == null) return null;
+
+    final mediaQuery = MediaQuery.maybeOf(element);
+    if (mediaQuery == null) {
+      return {
+        'x': frameRect.left,
+        'y': frameRect.top,
+        'width': frameRect.width,
+        'height': frameRect.height,
+      };
+    }
+
+    final padding = mediaQuery.padding;
+    final safeRect = Rect.fromLTRB(
+      padding.left,
+      padding.top,
+      mediaQuery.size.width - padding.right,
+      mediaQuery.size.height - padding.bottom,
+    );
+    final intersection = safeRect.intersect(frameRect);
+    final x = math.max(frameRect.left, safeRect.left);
+    final y = math.max(frameRect.top, safeRect.top);
+    final width = math.max(0.0, intersection.width);
+    final height = math.max(0.0, intersection.height);
+
+    return {
+      'x': x,
+      'y': y,
+      'width': width,
+      'height': height,
+    };
   }
 
   /// Extract the primary visible text from an element.
@@ -235,6 +301,7 @@ class ElementInventory {
       if (label != null && label.isNotEmpty && !seen.contains(label)) {
         final frame = getFrame(element);
         if (frame != null) {
+          final safeAreaLayoutGuideFrame = getSafeAreaLayoutGuideFrame(element);
           seen.add(label);
           results.add({
             'id': label,
@@ -245,6 +312,8 @@ class ElementInventory {
             'visible': true,
             'tappable': widget.properties.onTap != null,
             'frame': frame,
+            'safeAreaInsets': getSafeAreaInsets(element),
+            'safeAreaLayoutGuideFrame': safeAreaLayoutGuideFrame,
             'actions': widget.properties.onTap != null ? ['tap'] : [],
             'idSource': 'semantics',
           });
@@ -294,6 +363,8 @@ class ElementInventory {
     String? value;
     List<String> actions = [];
     String idSource = 'derived';
+    final safeAreaInsets = getSafeAreaInsets(element);
+    final safeAreaLayoutGuideFrame = getSafeAreaLayoutGuideFrame(element);
 
     // 1. Explicit ValueKey<String>
     final key = widget.key;
@@ -463,6 +534,8 @@ class ElementInventory {
       'visible': true,
       'tappable': tappable,
       'frame': frame,
+      'safeAreaInsets': safeAreaInsets,
+      'safeAreaLayoutGuideFrame': safeAreaLayoutGuideFrame,
       'actions': actions,
       'idSource': idSource,
     };
@@ -485,6 +558,11 @@ class ElementInventory {
 
     final frame = getFrame(element);
     if (frame != null) node['frame'] = frame;
+    node['safeAreaInsets'] = getSafeAreaInsets(element);
+    final safeAreaLayoutGuideFrame = getSafeAreaLayoutGuideFrame(element);
+    if (safeAreaLayoutGuideFrame != null) {
+      node['safeAreaLayoutGuideFrame'] = safeAreaLayoutGuideFrame;
+    }
 
     // Widget-specific properties
     if (widget is Text) {

--- a/README.md
+++ b/README.md
@@ -123,8 +123,8 @@ See [React Native guide](ReactNative/README.md) for full setup.
 |------|-------------|
 | `list_windows` | List visible app windows and their IDs |
 | `get_screen` | Current screen identity, controller/activity chain, confidence score |
-| `get_elements` | All visible interactive elements with id, type, frame, actions |
-| `get_view_tree` | Full view hierarchy with class, frame, properties, accessibility info |
+| `get_elements` | All visible interactive elements with id, type, frame, safe-area data, actions |
+| `get_view_tree` | Full view hierarchy with class, frame, safe-area data, properties, accessibility info |
 | `tap_element` | Tap by element identifier (buttons, cells, controls) |
 | `tap_text` | Tap by visible text content (finds text, walks to tappable ancestor) |
 | `tap_point` | Tap at screen coordinates |

--- a/ReactNative/README.md
+++ b/ReactNative/README.md
@@ -173,8 +173,8 @@ All methods are no-ops when `__DEV__` is false — no production impact.
 | Tool | Description |
 |------|-------------|
 | `get_screen` | Current screen identity, controller chain, confidence score |
-| `get_elements` | All visible interactive elements with id, type, frame, actions |
-| `get_view_tree` | Full view hierarchy with class, frame, properties, accessibility info |
+| `get_elements` | All visible interactive elements with id, type, frame, safe-area data, actions |
+| `get_view_tree` | Full view hierarchy with class, frame, safe-area data, properties, accessibility info |
 | `tap_element` | Tap by element identifier (buttons, cells, controls) |
 | `tap_point` | Tap at screen coordinates |
 | `type_text` | Type text into a field (by element ID or current responder) |

--- a/ReactNative/appreveal/android/src/main/kotlin/com/appreveal/elements/ElementInfo.kt
+++ b/ReactNative/appreveal/android/src/main/kotlin/com/appreveal/elements/ElementInfo.kt
@@ -34,6 +34,8 @@ data class ElementInfo(
     val visible: Boolean,
     val tappable: Boolean,
     val frame: ElementFrame,
+    val safeAreaInsets: ElementInsets,
+    val safeAreaLayoutGuideFrame: ElementFrame,
     val containerId: String?,
     val actions: List<String>,
     /** How the id was derived: "explicit", "text", "semantics", "derived" */
@@ -44,5 +46,12 @@ data class ElementInfo(
         val y: Double,
         val width: Double,
         val height: Double
+    )
+
+    data class ElementInsets(
+        val top: Double,
+        val leading: Double,
+        val bottom: Double,
+        val trailing: Double
     )
 }

--- a/ReactNative/appreveal/android/src/main/kotlin/com/appreveal/elements/ElementInventory.kt
+++ b/ReactNative/appreveal/android/src/main/kotlin/com/appreveal/elements/ElementInventory.kt
@@ -10,12 +10,17 @@ import android.widget.ScrollView
 import android.widget.SeekBar
 import android.widget.TextView
 import androidx.appcompat.widget.Toolbar
+import androidx.core.graphics.Insets
+import androidx.core.view.ViewCompat
+import androidx.core.view.WindowInsetsCompat
 import androidx.core.widget.NestedScrollView
 import androidx.recyclerview.widget.RecyclerView
 import com.appreveal.screen.ScreenResolver
 import com.appreveal.shared.MainThreadExecutor
 import com.google.android.material.bottomnavigation.BottomNavigationView
 import com.google.android.material.materialswitch.MaterialSwitch
+import kotlin.math.max
+import kotlin.math.min
 
 /**
  * Enumerates visible interactive elements from the Android view hierarchy.
@@ -209,6 +214,8 @@ internal object ElementInventory {
 
         val location = IntArray(2)
         view.getLocationOnScreen(location)
+        val frame = frameFor(view, location)
+        val systemInsets = systemSafeAreaInsets(view)
 
         return ElementInfo(
             id = id,
@@ -218,12 +225,9 @@ internal object ElementInventory {
             enabled = view.isEnabled && (view.isClickable || view.isFocusable || view is EditText),
             visible = view.visibility == View.VISIBLE && view.alpha > 0f,
             tappable = view.isClickable || view.hasOnClickListeners(),
-            frame = ElementInfo.ElementFrame(
-                x = location[0].toDouble(),
-                y = location[1].toDouble(),
-                width = view.width.toDouble(),
-                height = view.height.toDouble()
-            ),
+            frame = frame,
+            safeAreaInsets = safeAreaInsets(view, systemInsets),
+            safeAreaLayoutGuideFrame = safeAreaLayoutGuideFrame(frame, systemInsets),
             containerId = containerId,
             actions = availableActions(view),
             idSource = idSource
@@ -375,10 +379,21 @@ internal object ElementInventory {
 
         val location = IntArray(2)
         view.getLocationOnScreen(location)
+        val frame = frameFor(view, location)
+        val systemInsets = systemSafeAreaInsets(view)
+        val safeAreaInsets = safeAreaInsets(view, systemInsets)
 
         val node = mutableMapOf<String, Any>(
             "class" to view.javaClass.simpleName,
             "frame" to "${location[0]},${location[1]},${view.width},${view.height}",
+            "safeAreaInsets" to
+                mapOf(
+                    "top" to safeAreaInsets.top,
+                    "leading" to safeAreaInsets.leading,
+                    "bottom" to safeAreaInsets.bottom,
+                    "trailing" to safeAreaInsets.trailing
+                ),
+            "safeAreaLayoutGuideFrame" to safeAreaLayoutGuideFrameMap(frame, systemInsets),
             "hidden" to (view.visibility != View.VISIBLE),
             "alpha" to view.alpha,
             "userInteraction" to (view.isClickable || view.isFocusable),
@@ -438,6 +453,78 @@ internal object ElementInventory {
             }
         }
         return result
+    }
+
+    private fun frameFor(
+        view: View,
+        location: IntArray
+    ): ElementInfo.ElementFrame = ElementInfo.ElementFrame(
+        x = location[0].toDouble(),
+        y = location[1].toDouble(),
+        width = view.width.toDouble(),
+        height = view.height.toDouble()
+    )
+
+    private fun systemSafeAreaInsets(view: View): Insets =
+        ViewCompat.getRootWindowInsets(view)
+            ?.getInsets(WindowInsetsCompat.Type.systemBars() or WindowInsetsCompat.Type.displayCutout())
+            ?: Insets.NONE
+
+    private fun safeAreaInsets(
+        view: View,
+        systemInsets: Insets
+    ): ElementInfo.ElementInsets {
+        val isRightToLeft = ViewCompat.getLayoutDirection(view) == ViewCompat.LAYOUT_DIRECTION_RTL
+        return ElementInfo.ElementInsets(
+            top = systemInsets.top.toDouble(),
+            leading = if (isRightToLeft) systemInsets.right.toDouble() else systemInsets.left.toDouble(),
+            bottom = systemInsets.bottom.toDouble(),
+            trailing = if (isRightToLeft) systemInsets.left.toDouble() else systemInsets.right.toDouble()
+        )
+    }
+
+    private fun safeAreaLayoutGuideFrame(
+        frame: ElementInfo.ElementFrame,
+        systemInsets: Insets
+    ): ElementInfo.ElementFrame {
+        val decorView = ScreenResolver.currentActivity?.window?.decorView ?: return frame
+        val decorLocation = IntArray(2)
+        decorView.getLocationOnScreen(decorLocation)
+
+        val safeLeft = decorLocation[0].toDouble() + systemInsets.left
+        val safeTop = decorLocation[1].toDouble() + systemInsets.top
+        val safeRight = decorLocation[0].toDouble() + decorView.width - systemInsets.right
+        val safeBottom = decorLocation[1].toDouble() + decorView.height - systemInsets.bottom
+
+        val x = max(frame.x, safeLeft)
+        val y = max(frame.y, safeTop)
+        val right = min(frame.x + frame.width, safeRight)
+        val bottom = min(frame.y + frame.height, safeBottom)
+
+        return ElementInfo.ElementFrame(
+            x = x,
+            y = y,
+            width = max(0.0, right - x),
+            height = max(0.0, bottom - y)
+        )
+    }
+
+    private fun safeAreaLayoutGuideFrameMap(
+        frame: ElementInfo.ElementFrame,
+        systemInsets: Insets
+    ): Map<String, Double> {
+        val decorView = ScreenResolver.currentActivity?.window?.decorView
+        val safeFrame = if (decorView == null) {
+            frame
+        } else {
+            safeAreaLayoutGuideFrame(frame, systemInsets)
+        }
+        return mapOf(
+            "x" to safeFrame.x,
+            "y" to safeFrame.y,
+            "width" to safeFrame.width,
+            "height" to safeFrame.height
+        )
     }
 
     private fun findView(id: String, view: View): View? {

--- a/ReactNative/appreveal/android/src/main/kotlin/com/appreveal/mcpserver/MCPTools.kt
+++ b/ReactNative/appreveal/android/src/main/kotlin/com/appreveal/mcpserver/MCPTools.kt
@@ -63,6 +63,18 @@ internal fun registerBuiltInTools() {
                     addProperty("visible", if (el.visible) "true" else "false")
                     addProperty("tappable", if (el.tappable) "true" else "false")
                     addProperty("frame", "${el.frame.x.toInt()},${el.frame.y.toInt()},${el.frame.width.toInt()},${el.frame.height.toInt()}")
+                    add("safeAreaInsets", JsonObject().apply {
+                        addProperty("top", el.safeAreaInsets.top)
+                        addProperty("leading", el.safeAreaInsets.leading)
+                        addProperty("bottom", el.safeAreaInsets.bottom)
+                        addProperty("trailing", el.safeAreaInsets.trailing)
+                    })
+                    add("safeAreaLayoutGuideFrame", JsonObject().apply {
+                        addProperty("x", el.safeAreaLayoutGuideFrame.x)
+                        addProperty("y", el.safeAreaLayoutGuideFrame.y)
+                        addProperty("width", el.safeAreaLayoutGuideFrame.width)
+                        addProperty("height", el.safeAreaLayoutGuideFrame.height)
+                    })
                     addProperty("actions", el.actions.joinToString(","))
                     addProperty("idSource", el.idSource)
                 })

--- a/ReactNative/appreveal/ios/ElementInfo.swift
+++ b/ReactNative/appreveal/ios/ElementInfo.swift
@@ -31,6 +31,8 @@ public struct ElementInfo: Codable {
     public let visible: Bool
     public let tappable: Bool
     public let frame: ElementFrame
+    public let safeAreaInsets: ElementInsets
+    public let safeAreaLayoutGuideFrame: ElementFrame
     public let containerId: String?
     public let actions: [String]
     /// How the id was derived: "explicit", "text", "semantics", "derived"
@@ -41,5 +43,12 @@ public struct ElementInfo: Codable {
         public let y: Double
         public let width: Double
         public let height: Double
+    }
+
+    public struct ElementInsets: Codable {
+        public let top: Double
+        public let leading: Double
+        public let bottom: Double
+        public let trailing: Double
     }
 }

--- a/ReactNative/appreveal/ios/ElementInventory.swift
+++ b/ReactNative/appreveal/ios/ElementInventory.swift
@@ -189,6 +189,11 @@ final class ElementInventory {
         finalId = count == 0 ? resolvedId : "\(resolvedId)_\(count)"
 
         let screenFrame = view.convert(view.bounds, to: nil)
+        let layoutGuideFrame = view.convert(view.safeAreaLayoutGuide.layoutFrame, to: nil)
+        let safeAreaInsets = Self.makeSafeAreaInsets(
+            view.safeAreaInsets,
+            layoutDirection: view.effectiveUserInterfaceLayoutDirection
+        )
 
         return ElementInfo(
             id: finalId,
@@ -198,12 +203,9 @@ final class ElementInventory {
             enabled: view.isUserInteractionEnabled && (view as? UIControl)?.isEnabled ?? true,
             visible: !view.isHidden && view.alpha > 0,
             tappable: view is UIControl || view.gestureRecognizers?.isEmpty == false || view is UITableViewCell || view is UICollectionViewCell,
-            frame: ElementInfo.ElementFrame(
-                x: screenFrame.origin.x,
-                y: screenFrame.origin.y,
-                width: screenFrame.size.width,
-                height: screenFrame.size.height
-            ),
+            frame: Self.makeFrame(screenFrame),
+            safeAreaInsets: safeAreaInsets,
+            safeAreaLayoutGuideFrame: Self.makeFrame(layoutGuideFrame),
             containerId: containerId,
             actions: availableActions(for: view),
             idSource: idSource
@@ -325,9 +327,17 @@ final class ElementInventory {
         guard depth < maxDepth else { return [] }
 
         let screenFrame = view.convert(view.bounds, to: nil)
+        let layoutGuideFrame = view.convert(view.safeAreaLayoutGuide.layoutFrame, to: nil)
         var node: [String: Any] = [
             "class": String(describing: type(of: view)),
             "frame": "\(Int(screenFrame.origin.x)),\(Int(screenFrame.origin.y)),\(Int(screenFrame.size.width)),\(Int(screenFrame.size.height))",
+            "safeAreaInsets": Self.dictionary(
+                for: Self.makeSafeAreaInsets(
+                    view.safeAreaInsets,
+                    layoutDirection: view.effectiveUserInterfaceLayoutDirection
+                )
+            ),
+            "safeAreaLayoutGuideFrame": Self.dictionary(for: Self.makeFrame(layoutGuideFrame)),
             "hidden": view.isHidden,
             "alpha": view.alpha,
             "userInteraction": view.isUserInteractionEnabled,
@@ -397,6 +407,46 @@ final class ElementInventory {
             }
         }
         return nil
+    }
+
+    static func makeFrame(_ rect: CGRect) -> ElementInfo.ElementFrame {
+        ElementInfo.ElementFrame(
+            x: rect.origin.x,
+            y: rect.origin.y,
+            width: rect.size.width,
+            height: rect.size.height
+        )
+    }
+
+    static func makeSafeAreaInsets(
+        _ insets: UIEdgeInsets,
+        layoutDirection: UIUserInterfaceLayoutDirection
+    ) -> ElementInfo.ElementInsets {
+        let isRightToLeft = layoutDirection == .rightToLeft
+        return ElementInfo.ElementInsets(
+            top: insets.top,
+            leading: isRightToLeft ? insets.right : insets.left,
+            bottom: insets.bottom,
+            trailing: isRightToLeft ? insets.left : insets.right
+        )
+    }
+
+    private static func dictionary(for frame: ElementInfo.ElementFrame) -> [String: Double] {
+        [
+            "x": frame.x,
+            "y": frame.y,
+            "width": frame.width,
+            "height": frame.height
+        ]
+    }
+
+    private static func dictionary(for insets: ElementInfo.ElementInsets) -> [String: Double] {
+        [
+            "top": insets.top,
+            "leading": insets.leading,
+            "bottom": insets.bottom,
+            "trailing": insets.trailing
+        ]
     }
 }
 

--- a/ReactNative/appreveal/ios/MCPTools.swift
+++ b/ReactNative/appreveal/ios/MCPTools.swift
@@ -48,9 +48,21 @@ func registerBuiltInTools() {
                     "visible": el.visible ? "true" : "false",
                     "tappable": el.tappable ? "true" : "false",
                     "frame": "\(Int(el.frame.x)),\(Int(el.frame.y)),\(Int(el.frame.width)),\(Int(el.frame.height))",
+                    "safeAreaInsets": [
+                        "top": el.safeAreaInsets.top,
+                        "leading": el.safeAreaInsets.leading,
+                        "bottom": el.safeAreaInsets.bottom,
+                        "trailing": el.safeAreaInsets.trailing
+                    ],
+                    "safeAreaLayoutGuideFrame": [
+                        "x": el.safeAreaLayoutGuideFrame.x,
+                        "y": el.safeAreaLayoutGuideFrame.y,
+                        "width": el.safeAreaLayoutGuideFrame.width,
+                        "height": el.safeAreaLayoutGuideFrame.height
+                    ],
                     "actions": el.actions.joined(separator: ","),
                     "idSource": el.idSource
-                ] as [String: String]
+                ] as [String: Any]
             }
             return AnyCodable(["screenKey": ScreenResolver.shared.resolve().screenKey, "elements": list] as [String: Any])
         }

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -70,6 +70,8 @@ List all visible interactive elements on the current screen.
       "visible": "true",
       "tappable": "true",
       "frame": "32,364,338,34",
+      "safeAreaInsets": { "top": 0, "leading": 0, "bottom": 0, "trailing": 0 },
+      "safeAreaLayoutGuideFrame": { "x": 32, "y": 364, "width": 338, "height": 34 },
       "actions": "tap,type,clear",
       "idSource": "explicit"
     }
@@ -78,6 +80,9 @@ List all visible interactive elements on the current screen.
 ```
 
 - `idSource` — how the element's `id` was derived: `"explicit"` (accessibility identifier / tag / resource ID), `"text"` (from visible text), `"semantics"` (accessibility label / content description), `"tooltip"`, or `"derived"` (auto-generated fallback)
+- `safeAreaInsets` — per-view safe area insets using `leading` / `trailing` instead of physical `left` / `right`
+- `safeAreaLayoutGuideFrame` — the view's safe area layout guide frame in screen coordinates
+- Platform mapping: iOS/macOS use native safe areas, Android uses system bar/display-cutout insets, Flutter uses the nearest `MediaQuery.padding`
 
 Element types: `button`, `textField`, `label`, `image`, `toggle`, `slider`, `scrollView`, `tableView`, `collectionView`, `cell`, `navigationBar`, `tabBar`, `other`
 
@@ -96,6 +101,8 @@ Dump the full view hierarchy with class, frame, properties, and accessibility in
   "count": 142
 }
 ```
+
+Each node includes `safeAreaInsets` and `safeAreaLayoutGuideFrame` alongside the existing `frame` string so layout issues can be traced through the view hierarchy on every platform.
 
 ---
 

--- a/iOS/Sources/AppReveal/Elements/ElementInfo.swift
+++ b/iOS/Sources/AppReveal/Elements/ElementInfo.swift
@@ -33,6 +33,8 @@ public struct ElementInfo: Codable {
     public let visible: Bool
     public let tappable: Bool
     public let frame: ElementFrame
+    public let safeAreaInsets: ElementInsets
+    public let safeAreaLayoutGuideFrame: ElementFrame
     public let containerId: String?
     public let actions: [String]
     /// How the id was derived: "explicit", "text", "semantics", "tooltip", "derived"
@@ -43,6 +45,13 @@ public struct ElementInfo: Codable {
         public let y: Double
         public let width: Double
         public let height: Double
+    }
+
+    public struct ElementInsets: Codable {
+        public let top: Double
+        public let leading: Double
+        public let bottom: Double
+        public let trailing: Double
     }
 }
 

--- a/iOS/Sources/AppReveal/Elements/ElementInventory.swift
+++ b/iOS/Sources/AppReveal/Elements/ElementInventory.swift
@@ -189,6 +189,11 @@ final class ElementInventory {
         finalId = count == 0 ? resolvedId : "\(resolvedId)_\(count)"
 
         let screenFrame = view.convert(view.bounds, to: nil)
+        let layoutGuideFrame = view.convert(view.safeAreaLayoutGuide.layoutFrame, to: nil)
+        let safeAreaInsets = Self.makeSafeAreaInsets(
+            view.safeAreaInsets,
+            layoutDirection: view.effectiveUserInterfaceLayoutDirection
+        )
 
         return ElementInfo(
             id: finalId,
@@ -198,12 +203,9 @@ final class ElementInventory {
             enabled: view.isUserInteractionEnabled && (view as? UIControl)?.isEnabled ?? true,
             visible: !view.isHidden && view.alpha > 0,
             tappable: view is UIControl || view.gestureRecognizers?.isEmpty == false || view is UITableViewCell || view is UICollectionViewCell,
-            frame: ElementInfo.ElementFrame(
-                x: screenFrame.origin.x,
-                y: screenFrame.origin.y,
-                width: screenFrame.size.width,
-                height: screenFrame.size.height
-            ),
+            frame: Self.makeFrame(screenFrame),
+            safeAreaInsets: safeAreaInsets,
+            safeAreaLayoutGuideFrame: Self.makeFrame(layoutGuideFrame),
             containerId: containerId,
             actions: availableActions(for: view),
             idSource: idSource
@@ -323,9 +325,17 @@ final class ElementInventory {
         guard depth < maxDepth else { return [] }
 
         let screenFrame = view.convert(view.bounds, to: nil)
+        let layoutGuideFrame = view.convert(view.safeAreaLayoutGuide.layoutFrame, to: nil)
         var node: [String: Any] = [
             "class": String(describing: type(of: view)),
             "frame": "\(Int(screenFrame.origin.x)),\(Int(screenFrame.origin.y)),\(Int(screenFrame.size.width)),\(Int(screenFrame.size.height))",
+            "safeAreaInsets": Self.dictionary(
+                for: Self.makeSafeAreaInsets(
+                    view.safeAreaInsets,
+                    layoutDirection: view.effectiveUserInterfaceLayoutDirection
+                )
+            ),
+            "safeAreaLayoutGuideFrame": Self.dictionary(for: Self.makeFrame(layoutGuideFrame)),
             "hidden": view.isHidden,
             "alpha": view.alpha,
             "userInteraction": view.isUserInteractionEnabled,
@@ -395,6 +405,46 @@ final class ElementInventory {
             }
         }
         return nil
+    }
+
+    static func makeFrame(_ rect: CGRect) -> ElementInfo.ElementFrame {
+        ElementInfo.ElementFrame(
+            x: rect.origin.x,
+            y: rect.origin.y,
+            width: rect.size.width,
+            height: rect.size.height
+        )
+    }
+
+    static func makeSafeAreaInsets(
+        _ insets: UIEdgeInsets,
+        layoutDirection: UIUserInterfaceLayoutDirection
+    ) -> ElementInfo.ElementInsets {
+        let isRightToLeft = layoutDirection == .rightToLeft
+        return ElementInfo.ElementInsets(
+            top: insets.top,
+            leading: isRightToLeft ? insets.right : insets.left,
+            bottom: insets.bottom,
+            trailing: isRightToLeft ? insets.left : insets.right
+        )
+    }
+
+    private static func dictionary(for frame: ElementInfo.ElementFrame) -> [String: Double] {
+        [
+            "x": frame.x,
+            "y": frame.y,
+            "width": frame.width,
+            "height": frame.height
+        ]
+    }
+
+    private static func dictionary(for insets: ElementInfo.ElementInsets) -> [String: Double] {
+        [
+            "top": insets.top,
+            "leading": insets.leading,
+            "bottom": insets.bottom,
+            "trailing": insets.trailing
+        ]
     }
 }
 

--- a/iOS/Sources/AppReveal/Elements/MacOSElementInventory.swift
+++ b/iOS/Sources/AppReveal/Elements/MacOSElementInventory.swift
@@ -179,6 +179,11 @@ final class ElementInventory {
         let finalId = count == 0 ? resolvedId : "\(resolvedId)_\(count)"
 
         let windowFrame = view.convert(view.bounds, to: nil)
+        let layoutGuideFrame = view.convert(view.safeAreaRect, to: nil)
+        let safeAreaInsets = Self.makeSafeAreaInsets(
+            view.safeAreaInsets,
+            layoutDirection: view.userInterfaceLayoutDirection
+        )
 
         return ElementInfo(
             id: finalId,
@@ -188,12 +193,9 @@ final class ElementInventory {
             enabled: (view as? NSControl)?.isEnabled ?? true,
             visible: !view.isHiddenOrHasHiddenAncestor,
             tappable: view is NSControl || view is NSTableView,
-            frame: ElementInfo.ElementFrame(
-                x: windowFrame.origin.x,
-                y: windowFrame.origin.y,
-                width: windowFrame.size.width,
-                height: windowFrame.size.height
-            ),
+            frame: Self.makeFrame(windowFrame),
+            safeAreaInsets: safeAreaInsets,
+            safeAreaLayoutGuideFrame: Self.makeFrame(layoutGuideFrame),
             containerId: containerId,
             actions: availableActions(for: view),
             idSource: idSource
@@ -299,9 +301,17 @@ final class ElementInventory {
         guard depth < maxDepth else { return [] }
 
         let windowFrame = view.convert(view.bounds, to: nil)
+        let layoutGuideFrame = view.convert(view.safeAreaRect, to: nil)
         var node: [String: Any] = [
             "class": String(describing: type(of: view)),
             "frame": "\(Int(windowFrame.origin.x)),\(Int(windowFrame.origin.y)),\(Int(windowFrame.size.width)),\(Int(windowFrame.size.height))",
+            "safeAreaInsets": Self.dictionary(
+                for: Self.makeSafeAreaInsets(
+                    view.safeAreaInsets,
+                    layoutDirection: view.userInterfaceLayoutDirection
+                )
+            ),
+            "safeAreaLayoutGuideFrame": Self.dictionary(for: Self.makeFrame(layoutGuideFrame)),
             "hidden": view.isHidden,
             "alphaValue": view.alphaValue,
             "depth": depth
@@ -367,6 +377,46 @@ final class ElementInventory {
             }
         }
         return nil
+    }
+
+    private static func makeFrame(_ rect: CGRect) -> ElementInfo.ElementFrame {
+        ElementInfo.ElementFrame(
+            x: rect.origin.x,
+            y: rect.origin.y,
+            width: rect.size.width,
+            height: rect.size.height
+        )
+    }
+
+    private static func makeSafeAreaInsets(
+        _ insets: NSEdgeInsets,
+        layoutDirection: NSUserInterfaceLayoutDirection
+    ) -> ElementInfo.ElementInsets {
+        let isRightToLeft = layoutDirection == .rightToLeft
+        return ElementInfo.ElementInsets(
+            top: insets.top,
+            leading: isRightToLeft ? insets.right : insets.left,
+            bottom: insets.bottom,
+            trailing: isRightToLeft ? insets.left : insets.right
+        )
+    }
+
+    private static func dictionary(for frame: ElementInfo.ElementFrame) -> [String: Double] {
+        [
+            "x": frame.x,
+            "y": frame.y,
+            "width": frame.width,
+            "height": frame.height
+        ]
+    }
+
+    private static func dictionary(for insets: ElementInfo.ElementInsets) -> [String: Double] {
+        [
+            "top": insets.top,
+            "leading": insets.leading,
+            "bottom": insets.bottom,
+            "trailing": insets.trailing
+        ]
     }
 }
 

--- a/iOS/Sources/AppReveal/MCPServer/MCPTools.swift
+++ b/iOS/Sources/AppReveal/MCPServer/MCPTools.swift
@@ -511,9 +511,21 @@ private func registerIOSBuiltInTools() {
                     "visible": el.visible ? "true" : "false",
                     "tappable": el.tappable ? "true" : "false",
                     "frame": "\(Int(el.frame.x)),\(Int(el.frame.y)),\(Int(el.frame.width)),\(Int(el.frame.height))",
+                    "safeAreaInsets": [
+                        "top": el.safeAreaInsets.top,
+                        "leading": el.safeAreaInsets.leading,
+                        "bottom": el.safeAreaInsets.bottom,
+                        "trailing": el.safeAreaInsets.trailing
+                    ],
+                    "safeAreaLayoutGuideFrame": [
+                        "x": el.safeAreaLayoutGuideFrame.x,
+                        "y": el.safeAreaLayoutGuideFrame.y,
+                        "width": el.safeAreaLayoutGuideFrame.width,
+                        "height": el.safeAreaLayoutGuideFrame.height
+                    ],
                     "actions": el.actions.joined(separator: ","),
                     "idSource": el.idSource
-                ] as [String: String]
+                ] as [String: Any]
             }
             return AnyCodable(["screenKey": ScreenResolver.shared.resolve().screenKey, "elements": list] as [String: Any])
         }

--- a/iOS/Sources/AppReveal/MCPServer/MacOSMCPTools.swift
+++ b/iOS/Sources/AppReveal/MCPServer/MacOSMCPTools.swift
@@ -50,9 +50,21 @@ func registerMacOSBuiltInToolsImpl() {
                     "visible": el.visible ? "true" : "false",
                     "tappable": el.tappable ? "true" : "false",
                     "frame": "\(Int(el.frame.x)),\(Int(el.frame.y)),\(Int(el.frame.width)),\(Int(el.frame.height))",
+                    "safeAreaInsets": [
+                        "top": el.safeAreaInsets.top,
+                        "leading": el.safeAreaInsets.leading,
+                        "bottom": el.safeAreaInsets.bottom,
+                        "trailing": el.safeAreaInsets.trailing
+                    ],
+                    "safeAreaLayoutGuideFrame": [
+                        "x": el.safeAreaLayoutGuideFrame.x,
+                        "y": el.safeAreaLayoutGuideFrame.y,
+                        "width": el.safeAreaLayoutGuideFrame.width,
+                        "height": el.safeAreaLayoutGuideFrame.height
+                    ],
                     "actions": el.actions.joined(separator: ","),
                     "idSource": el.idSource
-                ] as [String: String]
+                ] as [String: Any]
             }
             return AnyCodable([
                 "screenKey": screenInfo.screenKey,

--- a/iOS/Tests/AppRevealTests/ElementInventoryGeometryTests.swift
+++ b/iOS/Tests/AppRevealTests/ElementInventoryGeometryTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import AppReveal
+
+#if os(iOS) && DEBUG
+
+final class ElementInventoryGeometryTests: XCTestCase {
+    @MainActor
+    func testMakeFramePreservesRectGeometry() {
+        let frame = ElementInventory.makeFrame(CGRect(x: 12.5, y: 34.25, width: 200.75, height: 88.5))
+
+        XCTAssertEqual(frame.x, 12.5)
+        XCTAssertEqual(frame.y, 34.25)
+        XCTAssertEqual(frame.width, 200.75)
+        XCTAssertEqual(frame.height, 88.5)
+    }
+
+    @MainActor
+    func testMakeSafeAreaInsetsUsesLeadingTrailingForLeftToRightLayouts() {
+        let insets = ElementInventory.makeSafeAreaInsets(
+            UIEdgeInsets(top: 10, left: 20, bottom: 30, right: 40),
+            layoutDirection: .leftToRight
+        )
+
+        XCTAssertEqual(insets.top, 10)
+        XCTAssertEqual(insets.leading, 20)
+        XCTAssertEqual(insets.bottom, 30)
+        XCTAssertEqual(insets.trailing, 40)
+    }
+
+    @MainActor
+    func testMakeSafeAreaInsetsUsesLeadingTrailingForRightToLeftLayouts() {
+        let insets = ElementInventory.makeSafeAreaInsets(
+            UIEdgeInsets(top: 10, left: 20, bottom: 30, right: 40),
+            layoutDirection: .rightToLeft
+        )
+
+        XCTAssertEqual(insets.top, 10)
+        XCTAssertEqual(insets.leading, 40)
+        XCTAssertEqual(insets.bottom, 30)
+        XCTAssertEqual(insets.trailing, 20)
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary
- add `safeAreaInsets` and `safeAreaLayoutGuideFrame` to `get_elements` and `get_view_tree` across iOS, macOS, Android, Flutter, and the React Native native bridges
- keep the existing `frame` field intact while widening element payloads to include structured safe-area metadata
- add iOS geometry tests and refresh the tool docs/README references
- fix the missing Android `drawToBitmap` import that was blocking local Kotlin compilation

## Why
Issue #1 needs layout-debugging metadata that shows where safe-area clipping starts in the hierarchy instead of forcing guesswork from frames alone.

## Validation
- `cd iOS && swiftlint lint --strict`
- `cd iOS && swift test`
- `cd Android && ANDROID_HOME=/Users/dictator/Library/Android/sdk ANDROID_SDK_ROOT=/Users/dictator/Library/Android/sdk ./gradlew ktlintCheck :appreveal:compileDebugKotlin`
- `cd Flutter/appreveal && flutter pub get && dart analyze --fatal-warnings`
- `cd ReactNative/appreveal && pnpm lint`
- `cd iOS && xcodebuild test -scheme AppReveal-Package -destination 'platform=iOS Simulator,id=400A6DB0-91FF-4406-973C-88F4DE1D0A5A'`
  - build/test target compiles, but execution on this machine is blocked by Xcode probing locked physical devices while launching the simulator run

Closes #1.
