### PR TITLE
feat(ios): AppReveal.privateAPITapsEnabled flag, default false

### DIFF
--- a/docs/ios.md
+++ b/docs/ios.md
@@ -25,6 +25,12 @@ import AppReveal
 
 func application(_ application: UIApplication, didFinishLaunchingWithOptions ...) -> Bool {
     #if DEBUG
+    // Optional: enable private-API tap injection for SwiftUI views on iOS 26+.
+    // On iOS 26+ SwiftUI gestures require IOHIDDigitizerEvent injection via private UIKit
+    // APIs. This is off by default — opt in if you need tap_point/tap_element to fire
+    // SwiftUI button actions.
+    AppReveal.privateAPITapsEnabled = true
+
     AppReveal.start()
 
     // Optional: register providers for deeper inspection

--- a/example/iOS/AppRevealExample/App/AppDelegate.swift
+++ b/example/iOS/AppRevealExample/App/AppDelegate.swift
@@ -17,6 +17,7 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         ExampleStateContainer.shared.isLoggedIn = true
 
         // One-line AppReveal integration
+        AppReveal.privateAPITapsEnabled = true   // enable iOS 26 SwiftUI tap injection
         AppReveal.start()
 
         // Register providers

--- a/iOS/Sources/AppReveal/AppReveal.swift
+++ b/iOS/Sources/AppReveal/AppReveal.swift
@@ -16,6 +16,17 @@ public final class AppReveal {
 
     private init() {}
 
+    /// Allow AppReveal to use private UIKit APIs for synthetic tap delivery on iOS 26+.
+    ///
+    /// When `true`, `tap_point` and `tap_element` on SwiftUI views inject an
+    /// `IOHIDDigitizerEvent` via `UIApplication._enqueueHIDEvent:` so SwiftUI gesture
+    /// recognisers fire correctly. This is the only reliable tap path on iOS 26+, but
+    /// requires private Apple APIs. Opt-in because some teams prefer to avoid private
+    /// API usage even in debug builds. Set to `true` before calling `AppReveal.start()`.
+    ///
+    /// Defaults to `false`.
+    public static var privateAPITapsEnabled: Bool = false
+
     /// Start the AppReveal MCP server and Bonjour advertising.
     /// - Parameter port: Optional specific port. Uses a dynamic port if nil.
     public static func start(port: UInt16? = nil) {

--- a/iOS/Sources/AppReveal/Interaction/InteractionEngine.swift
+++ b/iOS/Sources/AppReveal/Interaction/InteractionEngine.swift
@@ -192,7 +192,7 @@ final class InteractionEngine {
     // those methods on earlier OS versions.
     private static func deliverSyntheticTap(at windowPoint: CGPoint, to view: UIView) {
         guard let window = view.window else { return }
-        if #available(iOS 26, *) {
+        if #available(iOS 26, *), AppReveal.privateAPITapsEnabled {
             if hidEventTap(at: windowPoint, in: window) { return }
         }
         kvcTouchTap(at: windowPoint, to: view, window: window)


### PR DESCRIPTION
## Summary

- Adds `AppReveal.privateAPITapsEnabled` (default `false`) to gate the iOS 26 private-API tap path
- The IOHIDDigitizerEvent injection is now opt-in — teams that prefer no private API usage in debug builds can leave it off
- When disabled, `tap_point` on SwiftUI views falls back to `touchesBegan`/`touchesEnded` (works on iOS < 26, silent no-op on iOS 26+)
- Example app sets it to `true` to keep the Tap Calibration test working
- `docs/ios.md` updated with the opt-in snippet

## Usage

```swift
#if DEBUG
AppReveal.privateAPITapsEnabled = true  // enable iOS 26 SwiftUI tap injection
AppReveal.start()
#endif
```

## Test plan

- [x] Build succeeded
- [x] Manual MCP test with flag enabled: `tap_point` → `"SwiftUI button tapped!"` ✓
- [x] All linters pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)