### PR TITLE
feat(ios): compile-time APPREVEAL_PRIVATE_API_TAPS flag for App Store safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,11 @@ AppReveal.start()
 #endif
 ```
 
-See [iOS guide](docs/ios.md) for full setup.
+#### SwiftUI tap support on iOS 26+
+
+`tap_point` and `tap_element` on SwiftUI views require private UIKit APIs on iOS 26+. AppReveal compiles this code in automatically for **debug builds** and compiles it **out for release builds** — no private symbols reach your App Store binary. No setup needed.
+
+To opt out of private APIs entirely (even in debug builds), remove the `swiftSettings` line from AppReveal's `Package.swift`. See [iOS guide](docs/ios.md) for details.
 
 ### macOS
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -103,7 +103,7 @@ Executes UI actions on the main thread:
 
 Uses platform-native event dispatch and direct view/control method calls. Scroll uses `UIScrollView.setContentOffset` on iOS and `NSScrollView` APIs on macOS.
 
-**iOS 26+ SwiftUI tap delivery:** On iOS 26+ SwiftUI's gesture engine runs entirely inside UIKit's window-level event dispatch; direct `touchesBegan`/`touchesEnded` calls on `_UIHostingView` are ignored. `tap_point` and `tap_element` on SwiftUI targets instead synthesise an `IOHIDDigitizerEvent` (hand + finger sub-event), bind it to the target window via `BKSHIDEventSetDigitizerInfo`, and inject via `UIApplication._enqueueHIDEvent:`. This is the only reliable path and intentionally uses private API — AppReveal is a debug-only library and is never shipped to production.
+**iOS 26+ SwiftUI tap delivery (`APPREVEAL_PRIVATE_API_TAPS`):** On iOS 26+ SwiftUI's gesture engine runs entirely inside UIKit's window-level event dispatch; direct `touchesBegan`/`touchesEnded` calls on `_UIHostingView` are ignored. When the `APPREVEAL_PRIVATE_API_TAPS` compiler flag is defined, `tap_point` and `tap_element` on SwiftUI targets synthesise an `IOHIDDigitizerEvent` (hand + finger sub-event), bind it to the target window via `BKSHIDEventSetDigitizerInfo`, and inject via `UIApplication._enqueueHIDEvent:`. The entire implementation is inside `#if APPREVEAL_PRIVATE_API_TAPS` — no private API symbols appear in binaries built without the flag, making it safe for App Store review.
 
 ### ScreenshotCapture / MacOSScreenshotCapture
 
@@ -328,7 +328,7 @@ iOS/                                   (single Swift package for iOS + macOS)
 ## Design principles
 
 1. **Convention over configuration** -- works with minimal setup if naming conventions are followed
-2. **Explicit over magic** -- no SwiftUI internal tree walking; private API is used only where the public API is insufficient (e.g. iOS 26 SwiftUI tap delivery via `_enqueueHIDEvent:`)
+2. **Explicit over magic** -- no SwiftUI internal tree walking; private API gated behind `APPREVEAL_PRIVATE_API_TAPS` compile flag and compiled out by default
 3. **Read-first** -- observation tools before mutation tools
 4. **Debug-only** -- zero production impact, compile-time guarantee
 5. **Standard transport** -- MCP Streamable HTTP for maximum client compatibility

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -25,12 +25,6 @@ import AppReveal
 
 func application(_ application: UIApplication, didFinishLaunchingWithOptions ...) -> Bool {
     #if DEBUG
-    // Optional: enable private-API tap injection for SwiftUI views on iOS 26+.
-    // On iOS 26+ SwiftUI gestures require IOHIDDigitizerEvent injection via private UIKit
-    // APIs. This is off by default — opt in if you need tap_point/tap_element to fire
-    // SwiftUI button actions.
-    AppReveal.privateAPITapsEnabled = true
-
     AppReveal.start()
 
     // Optional: register providers for deeper inspection
@@ -44,6 +38,28 @@ func application(_ application: UIApplication, didFinishLaunchingWithOptions ...
 ```
 
 WKWebView support works automatically -- no additional integration needed.
+
+### SwiftUI tap support on iOS 26+
+
+On iOS 26+ SwiftUI gesture recognisers require private UIKit APIs for synthetic tap delivery (`IOHIDDigitizerEvent` + `UIApplication._enqueueHIDEvent:`). AppReveal gates this code behind the `APPREVEAL_PRIVATE_API_TAPS` compile flag, which is set automatically for debug builds in `Package.swift`:
+
+| Build configuration | Private API code | Notes |
+|---|---|---|
+| Debug | ✅ compiled in | SwiftUI taps work |
+| Release | ❌ absent | No private symbols — safe for App Store review |
+
+No setup needed. The flag is already wired up in AppReveal's `Package.swift`.
+
+#### Opting out of private APIs entirely
+
+If your team prefers zero private API usage even in debug builds, remove (or comment out) the `swiftSettings` entry from AppReveal's `Package.swift`:
+
+```swift
+// iOS/Package.swift — remove to disable private API taps in all builds:
+// .define("APPREVEAL_PRIVATE_API_TAPS", .when(configuration: .debug))
+```
+
+Without the flag, `tap_point` still works for all UIKit views and SwiftUI views on iOS < 26. On iOS 26+ SwiftUI buttons will not respond to synthetic taps.
 
 ### 2. Add screen identity (optional)
 

--- a/example/iOS/AppRevealExample/App/AppDelegate.swift
+++ b/example/iOS/AppRevealExample/App/AppDelegate.swift
@@ -17,7 +17,6 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
         ExampleStateContainer.shared.isLoggedIn = true
 
         // One-line AppReveal integration
-        AppReveal.privateAPITapsEnabled = true   // enable iOS 26 SwiftUI tap injection
         AppReveal.start()
 
         // Register providers

--- a/iOS/Package.swift
+++ b/iOS/Package.swift
@@ -21,7 +21,14 @@ let package = Package(
     targets: [
         .target(
             name: "AppReveal",
-            path: "Sources/AppReveal"
+            path: "Sources/AppReveal",
+            swiftSettings: [
+                // Compile in the private-API tap path (IOHIDDigitizerEvent injection) for
+                // debug builds only. Release builds have zero private API symbols — safe for
+                // App Store review. Remove this line if you want to opt out of private APIs
+                // entirely, even in debug builds.
+                .define("APPREVEAL_PRIVATE_API_TAPS", .when(configuration: .debug))
+            ]
         ),
         .target(
             name: "AppRevealClient",

--- a/iOS/Sources/AppReveal/AppReveal.swift
+++ b/iOS/Sources/AppReveal/AppReveal.swift
@@ -16,17 +16,6 @@ public final class AppReveal {
 
     private init() {}
 
-    /// Allow AppReveal to use private UIKit APIs for synthetic tap delivery on iOS 26+.
-    ///
-    /// When `true`, `tap_point` and `tap_element` on SwiftUI views inject an
-    /// `IOHIDDigitizerEvent` via `UIApplication._enqueueHIDEvent:` so SwiftUI gesture
-    /// recognisers fire correctly. This is the only reliable tap path on iOS 26+, but
-    /// requires private Apple APIs. Opt-in because some teams prefer to avoid private
-    /// API usage even in debug builds. Set to `true` before calling `AppReveal.start()`.
-    ///
-    /// Defaults to `false`.
-    public static var privateAPITapsEnabled: Bool = false
-
     /// Start the AppReveal MCP server and Bonjour advertising.
     /// - Parameter port: Optional specific port. Uses a dynamic port if nil.
     public static func start(port: UInt16? = nil) {

--- a/iOS/Sources/AppReveal/Interaction/InteractionEngine.swift
+++ b/iOS/Sources/AppReveal/Interaction/InteractionEngine.swift
@@ -192,9 +192,11 @@ final class InteractionEngine {
     // those methods on earlier OS versions.
     private static func deliverSyntheticTap(at windowPoint: CGPoint, to view: UIView) {
         guard let window = view.window else { return }
-        if #available(iOS 26, *), AppReveal.privateAPITapsEnabled {
+        #if APPREVEAL_PRIVATE_API_TAPS
+        if #available(iOS 26, *) {
             if hidEventTap(at: windowPoint, in: window) { return }
         }
+        #endif
         kvcTouchTap(at: windowPoint, to: view, window: window)
     }
 
@@ -202,9 +204,13 @@ final class InteractionEngine {
     // finger sub-event, bind it to the target window via BKSHIDEventSetDigitizerInfo, and
     // inject it into UIKit's HID pipeline via UIApplication._enqueueHIDEvent:.
     //
+    // This entire method is compiled out unless APPREVEAL_PRIVATE_API_TAPS is defined,
+    // ensuring private API symbols are absent from production/review binaries.
+    //
     // Coordinates are absolute screen points (not normalised 0–1).
     // Event-mask values: range=0x1, touch=0x2, position=0x4.
     // Parent hand mask = child masks ∩ {touch, attribute} → 0x2 for a single finger tap.
+    #if APPREVEAL_PRIVATE_API_TAPS
     @available(iOS 26, *)
     private static func hidEventTap(at windowPoint: CGPoint, in window: UIWindow) -> Bool {
         let iokit = dlopen("/System/Library/Frameworks/IOKit.framework/IOKit", RTLD_NOW)
@@ -295,6 +301,7 @@ final class InteractionEngine {
         }
         return true
     }
+    #endif // APPREVEAL_PRIVATE_API_TAPS
 
     // Fallback for iOS < 26: synthesise a UITouch via KVC and deliver via
     // touchesBegan/touchesEnded (SwiftUI overrode these on pre-iOS 26).


### PR DESCRIPTION
## Summary

- Replaces the v0.9.5 runtime `privateAPITapsEnabled` flag with a `#if APPREVEAL_PRIVATE_API_TAPS` compile-time guard
- `Package.swift` defines the flag automatically for debug builds; release builds have zero private API symbols (IOHIDDigitizerEvent, BKSHIDEventSetDigitizerInfo, BackBoardServices) — safe for App Store review
- Removes `AppReveal.privateAPITapsEnabled` from the public API; no app-side setup needed
- Documents opt-out (remove the `swiftSettings` line from `Package.swift`) in README and `docs/ios.md`

## Why compile-time vs runtime

A runtime flag still ships the private API *code* in the binary — App Store review can detect private symbol references even if a code path is never executed. A compile-time `#if` guard means the symbols are physically absent from the binary when not defined.

## Test plan

- [x] Debug build: `-DAPPREVEAL_PRIVATE_API_TAPS` confirmed in swiftc invocation (build log)
- [x] End-to-end: `tap_point {x:201, y:480}` on Tap Calibration screen → `"SwiftUI button tapped!"`
- [x] All linters pass (SwiftLint, dart analyze, eslint)

🤖 Generated with [Claude Code](https://claude.com/claude-code)