### PR TITLE
fix(ios): expose SwiftUI elements via .appReveal() modifier; fix version constant

### DIFF
--- a/docs/ios.md
+++ b/docs/ios.md
@@ -61,7 +61,32 @@ If your team prefers zero private API usage even in debug builds, remove (or com
 
 Without the flag, `tap_point` still works for all UIKit views and SwiftUI views on iOS < 26. On iOS 26+ SwiftUI buttons will not respond to synthetic taps.
 
-### 2. Add screen identity (optional)
+### 2. Register SwiftUI elements (required on iOS 26+)
+
+On iOS 26, SwiftUI defers building its accessibility tree until VoiceOver is actually running. AppReveal's in-process scan can't trigger that build, so SwiftUI buttons inside `UIHostingController` are invisible to `get_elements` by default.
+
+**Fix:** apply `.appReveal("id")` to SwiftUI views that agents need to interact with.
+
+```swift
+// Works on iOS 16+ — no-op in release (compiled only under #if DEBUG)
+Button(action: sendMessage) {
+    Image(systemName: "arrow.up.circle.fill")
+}
+#if DEBUG
+.appReveal("chat.send_button", label: "Send")
+#endif
+
+Button("Submit") { submit() }
+#if DEBUG
+.appReveal("form.submit")
+#endif
+```
+
+After this, `get_elements` returns the element with `idSource: "appReveal"` and `tap_element("chat.send_button")` works correctly — the tap is delivered through the same SwiftUI-aware IOHIDDigitizerEvent path as `tap_point`.
+
+**Elements without `.appReveal()`:** UIKit views (`UIButton`, `UITextField`, `UISwitch`, etc.) and SwiftUI elements with an `accessibilityIdentifier` set **on iOS < 26** continue to work automatically.
+
+### 3. Add screen identity (optional)
 
 Screen identity is auto-derived from class names -- `LoginViewController` becomes key `"login"`, title `"Login"`. Override only when you want a custom key:
 

--- a/example/iOS/AppRevealExample/Screens/TapCalibrationViewController.swift
+++ b/example/iOS/AppRevealExample/Screens/TapCalibrationViewController.swift
@@ -6,6 +6,7 @@ final class TapCalibrationViewController: UIViewController {
     private let instructionLabel = UILabel()
     private let targetView = UIView()
     private let resultLabel = UILabel()
+    private let imageButtonResultLabel = UILabel()
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -39,6 +40,14 @@ final class TapCalibrationViewController: UIViewController {
         resultLabel.accessibilityIdentifier = "calibration.result"
         view.addSubview(resultLabel)
 
+        imageButtonResultLabel.text = "Image button not yet tapped"
+        imageButtonResultLabel.textAlignment = .center
+        imageButtonResultLabel.font = .monospacedSystemFont(ofSize: 13, weight: .regular)
+        imageButtonResultLabel.textColor = .secondaryLabel
+        imageButtonResultLabel.translatesAutoresizingMaskIntoConstraints = false
+        imageButtonResultLabel.accessibilityIdentifier = "calibration.image_button_result"
+        view.addSubview(imageButtonResultLabel)
+
         NSLayoutConstraint.activate([
             instructionLabel.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor, constant: 32),
             instructionLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
@@ -51,24 +60,29 @@ final class TapCalibrationViewController: UIViewController {
 
             resultLabel.topAnchor.constraint(equalTo: targetView.bottomAnchor, constant: 32),
             resultLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
-            resultLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24)
+            resultLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24),
+
+            imageButtonResultLabel.topAnchor.constraint(equalTo: resultLabel.bottomAnchor, constant: 8),
+            imageButtonResultLabel.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: 24),
+            imageButtonResultLabel.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: -24)
         ])
     }
 
     private func embedSwiftUIButton() {
-        let swiftUIVC = UIHostingController(rootView: SwiftUITapTestView(onTap: { [weak self] in
-            self?.swiftUIButtonTapped()
-        }))
+        let swiftUIVC = UIHostingController(rootView: SwiftUITapTestView(
+            onTap: { [weak self] in self?.swiftUIButtonTapped() },
+            onImageTap: { [weak self] in self?.swiftUIImageButtonTapped() }
+        ))
         addChild(swiftUIVC)
         swiftUIVC.view.translatesAutoresizingMaskIntoConstraints = false
         view.addSubview(swiftUIVC.view)
         swiftUIVC.didMove(toParent: self)
 
         NSLayoutConstraint.activate([
-            swiftUIVC.view.topAnchor.constraint(equalTo: resultLabel.bottomAnchor, constant: 32),
+            swiftUIVC.view.topAnchor.constraint(equalTo: imageButtonResultLabel.bottomAnchor, constant: 16),
             swiftUIVC.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             swiftUIVC.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            swiftUIVC.view.heightAnchor.constraint(equalToConstant: 100)
+            swiftUIVC.view.heightAnchor.constraint(equalToConstant: 130)
         ])
     }
 
@@ -90,25 +104,46 @@ final class TapCalibrationViewController: UIViewController {
         resultLabel.text = "SwiftUI button tapped!"
         resultLabel.textColor = .systemBlue
     }
+
+    private func swiftUIImageButtonTapped() {
+        imageButtonResultLabel.text = "SwiftUI image button tapped!"
+        imageButtonResultLabel.textColor = .systemOrange
+    }
 }
 
 private struct SwiftUITapTestView: View {
     let onTap: () -> Void
+    let onImageTap: () -> Void
 
     var body: some View {
         VStack(spacing: 8) {
             Text("SwiftUI Button Test")
                 .font(.caption)
                 .foregroundStyle(.secondary)
-            Button(action: onTap) {
-                Text("Tap Me (SwiftUI)")
-                    .frame(maxWidth: .infinity)
-                    .padding()
-                    .background(Color.blue)
-                    .foregroundStyle(.white)
-                    .clipShape(RoundedRectangle(cornerRadius: 8))
+            HStack(spacing: 12) {
+                Button(action: onTap) {
+                    Text("Tap Me (SwiftUI)")
+                        .frame(maxWidth: .infinity)
+                        .padding()
+                        .background(Color.blue)
+                        .foregroundStyle(.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 8))
+                }
+                .accessibilityIdentifier("calibration.swiftui_button")
+                #if DEBUG
+                .appReveal("calibration.swiftui_button", label: "Tap Me (SwiftUI)")
+                #endif
+                // Image-only button — no label/identifier. Use .appReveal() for discovery on iOS 26+.
+                Button(action: onImageTap) {
+                    Image(systemName: "arrow.up.circle.fill")
+                        .resizable()
+                        .frame(width: 44, height: 44)
+                        .foregroundStyle(Color.orange)
+                }
+                #if DEBUG
+                .appReveal("calibration.image_button", label: "Send")
+                #endif
             }
-            .accessibilityIdentifier("calibration.swiftui_button")
             .padding(.horizontal, 24)
         }
     }

--- a/iOS/Sources/AppReveal/AppRevealVersion.swift
+++ b/iOS/Sources/AppReveal/AppRevealVersion.swift
@@ -2,5 +2,5 @@
 // Update this constant on every release to match the git tag.
 
 enum AppRevealVersion {
-    static let current = "0.9.3"
+    static let current = "0.9.7"
 }

--- a/iOS/Sources/AppReveal/Elements/AccessibilityElementInventory.swift
+++ b/iOS/Sources/AppReveal/Elements/AccessibilityElementInventory.swift
@@ -55,6 +55,9 @@ struct TapTargetResolveResult {
 enum TapTarget {
     case view(UIView)
     case accessibility(AccessibilityResolvedTarget)
+    /// Fallback for SwiftUI elements registered via .appReveal() whose frame is known
+    /// but that have no backing UIView or UIAccessibilityElement (iOS 26+).
+    case point(CGPoint)
 }
 
 @MainActor
@@ -306,9 +309,21 @@ final class AccessibilityElementInventory {
         visited: inout Set<ObjectIdentifier>,
         visitor: (AccessibilityResolvedTarget) -> Void
     ) {
-        guard let arr = (element.value(forKey: "accessibilityElements") as? [Any]), !arr.isEmpty else { return }
+        // SwiftUI virtual accessibility proxy nodes expose children via accessibilityElementCount /
+        // accessibilityElement(at:) rather than a KVC-accessible "accessibilityElements" key.
+        // Try the array property first; fall back to count/index for SwiftUI nodes.
+        let rawArr: [Any]
+        if let arr = element.value(forKey: "accessibilityElements") as? [Any], !arr.isEmpty {
+            rawArr = arr
+        } else {
+            let count = element.accessibilityElementCount()
+            guard count > 0, count < 100_000 else { return }
+            rawArr = (0..<count).compactMap { element.accessibilityElement(at: $0) }
+        }
+        guard !rawArr.isEmpty else { return }
+
         let subContainerId = accessibilityIdentifier(for: element) ?? containerId
-        for sub in arr {
+        for sub in rawArr {
             guard let rawSub = sub as? NSObject, !(rawSub is UIView) else { continue }
             let objectId = ObjectIdentifier(rawSub)
             guard visited.insert(objectId).inserted else { continue }
@@ -355,10 +370,15 @@ final class AccessibilityElementInventory {
         if let label = accessibilityLabel(for: element), !label.isEmpty {
             return (ElementInventory.normalizeToId(label), "semantics")
         }
-        let typeName = String(describing: type(of: element))
-            .lowercased()
-            .replacingOccurrences(of: "ui", with: "")
-        return (typeName, "derived")
+        // Use trait to derive a human-readable type prefix for unlabeled elements
+        // (e.g. SwiftUI image-only buttons with no accessibilityLabel set).
+        let traits = accessibilityTraits(for: element)
+        if traits.contains(.button) { return ("button", "derived") }
+        if traits.contains(.link) { return ("link", "derived") }
+        if traits.contains(.header) { return ("header", "derived") }
+        if traits.contains(.image) { return ("image", "derived") }
+        if traits.contains(.adjustable) { return ("slider", "derived") }
+        return ("element", "derived")
     }
 
     private func classifyElement(_ element: NSObject) -> ElementType {

--- a/iOS/Sources/AppReveal/Elements/ElementInventory.swift
+++ b/iOS/Sources/AppReveal/Elements/ElementInventory.swift
@@ -33,6 +33,7 @@ final class ElementInventory {
                 seenAccessibilityElements: &seenAccessibilityElements
             )
         }
+        appendSwiftUIRegisteredElements(to: &elements, seenIds: &seenIds)
         return elements
     }
 
@@ -121,6 +122,11 @@ final class ElementInventory {
             if let accessibilityTarget = AccessibilityElementInventory.shared.findElement(byVisibleText: id, in: ref.nativeWindow) {
                 return .accessibility(accessibilityTarget)
             }
+        }
+
+        // Check elements registered via .appReveal() modifier (required for SwiftUI on iOS 26+).
+        if let entry = SwiftUIElementRegistry.shared.findElement(byId: id) {
+            return .point(entry.frame.center)
         }
 
         return nil
@@ -596,6 +602,36 @@ final class ElementInventory {
             "bottom": insets.bottom,
             "trailing": insets.trailing
         ]
+    }
+
+    private func appendSwiftUIRegisteredElements(
+        to elements: inout [ElementInfo],
+        seenIds: inout [String: Int]
+    ) {
+        for entry in SwiftUIElementRegistry.shared.currentElements() {
+            let count = seenIds[entry.id, default: 0]
+            seenIds[entry.id] = count + 1
+            let finalId = count == 0 ? entry.id : "\(entry.id)_\(count)"
+            let frame = entry.frame
+            let safeAreaInsets = ElementInfo.ElementInsets(top: 0, leading: 0, bottom: 0, trailing: 0)
+            elements.append(
+                ElementInfo(
+                    id: finalId,
+                    type: .button,
+                    label: entry.label,
+                    value: nil,
+                    enabled: true,
+                    visible: !frame.isEmpty,
+                    tappable: true,
+                    frame: Self.makeFrame(frame),
+                    safeAreaInsets: safeAreaInsets,
+                    safeAreaLayoutGuideFrame: Self.makeFrame(frame),
+                    containerId: nil,
+                    actions: ["tap"],
+                    idSource: "appReveal"
+                )
+            )
+        }
     }
 
     private func candidateWindows(windowId: String?) -> [WindowRef] {

--- a/iOS/Sources/AppReveal/Elements/SwiftUIElementRegistry.swift
+++ b/iOS/Sources/AppReveal/Elements/SwiftUIElementRegistry.swift
@@ -1,0 +1,135 @@
+// SwiftUI opt-in element registration for iOS 26+
+//
+// On iOS 26, _UIHostingView returns an empty accessibilityElements array and
+// accessibilityElementCount() == 0 when VoiceOver is off. SwiftUI defers
+// building its accessibility tree to when a real assistive technology is running.
+// AppReveal's in-process query cannot trigger that build without VoiceOver.
+//
+// Solution: apps opt in by applying .appReveal("id") to SwiftUI views.
+// The modifier tracks the view's global frame via PreferenceKey and registers
+// it with SwiftUIElementRegistry, which ElementInventory includes in get_elements.
+
+import Foundation
+
+#if os(iOS)
+
+import UIKit
+import SwiftUI
+
+#if DEBUG
+
+@MainActor
+final class SwiftUIElementRegistry {
+
+    static let shared = SwiftUIElementRegistry()
+
+    private struct Entry {
+        let frame: CGRect
+        let label: String?
+    }
+
+    private var entries: [String: Entry] = [:]
+
+    private init() {}
+
+    func register(id: String, frame: CGRect, label: String?) {
+        entries[id] = Entry(frame: frame, label: label)
+    }
+
+    func unregister(id: String) {
+        entries.removeValue(forKey: id)
+    }
+
+    func currentElements() -> [(id: String, frame: CGRect, label: String?)] {
+        entries.map { (id: $0.key, frame: $0.value.frame, label: $0.value.label) }
+    }
+
+    func findElement(byId id: String) -> (id: String, frame: CGRect, label: String?)? {
+        guard let entry = entries[id] else { return nil }
+        return (id: id, frame: entry.frame, label: entry.label)
+    }
+}
+
+// MARK: - CGRect convenience
+
+extension CGRect {
+    var center: CGPoint { CGPoint(x: midX, y: midY) }
+}
+
+// MARK: - SwiftUI PreferenceKey
+
+private struct AppRevealFramePreference: PreferenceKey {
+    static let defaultValue: CGRect = .zero
+    static func reduce(value: inout CGRect, nextValue: () -> CGRect) {
+        value = nextValue()
+    }
+}
+
+// MARK: - ViewModifier
+
+struct AppRevealModifier: ViewModifier {
+    let id: String
+    let label: String?
+
+    func body(content: Content) -> some View {
+        content
+            .background(
+                GeometryReader { geo in
+                    Color.clear
+                        .preference(
+                            key: AppRevealFramePreference.self,
+                            value: geo.frame(in: .global)
+                        )
+                }
+            )
+            .onPreferenceChange(AppRevealFramePreference.self) { frame in
+                guard !frame.isEmpty else { return }
+                let registeredId = id
+                let registeredLabel = label
+                Task { @MainActor in
+                    SwiftUIElementRegistry.shared.register(
+                        id: registeredId,
+                        frame: frame,
+                        label: registeredLabel
+                    )
+                }
+            }
+            .onDisappear {
+                let registeredId = id
+                Task { @MainActor in
+                    SwiftUIElementRegistry.shared.unregister(id: registeredId)
+                }
+            }
+    }
+}
+
+// MARK: - Public View extension
+
+public extension View {
+    /// Register this SwiftUI view as a discoverable AppReveal element.
+    ///
+    /// Required on iOS 26+ for SwiftUI elements that should appear in `get_elements`.
+    /// SwiftUI defers building its accessibility tree until VoiceOver is active, so
+    /// AppReveal's in-process scan cannot find these elements automatically.
+    ///
+    /// Usage:
+    /// ```swift
+    /// Button(action: send) {
+    ///     Image(systemName: "arrow.up.circle.fill")
+    /// }
+    /// #if DEBUG
+    /// .appReveal("chat.send_button", label: "Send")
+    /// #endif
+    /// ```
+    ///
+    /// - Parameters:
+    ///   - id: Stable dot-namespaced identifier (e.g. `"chat.send_button"`).
+    ///   - label: Optional human-readable label for the element.
+    func appReveal(_ id: String, label: String? = nil) -> some View {
+        modifier(AppRevealModifier(id: id, label: label))
+    }
+}
+
+#endif
+
+#endif

--- a/iOS/Sources/AppReveal/Interaction/InteractionEngine.swift
+++ b/iOS/Sources/AppReveal/Interaction/InteractionEngine.swift
@@ -358,6 +358,11 @@ final class InteractionEngine {
             }
             let hitView = ref.nativeWindow.hitTest(accessibilityTarget.centerPoint, with: nil)
             return performTap(onView: hitView, at: accessibilityTarget.centerPoint)
+        case .point(let point):
+            // SwiftUI element registered via .appReveal() — no UIView backing.
+            // Delegate to tap(point:) which handles SwiftUI hosting views, HID events,
+            // and the full fallback stack. postTapPoint is called inside tap(point:).
+            return tap(point: point, windowId: windowId)
         }
     }
 
@@ -617,6 +622,11 @@ final class InteractionEngine {
             return editableAncestor(for: view)
         case .accessibility(let accessibilityTarget):
             if let hitView = hitView(at: accessibilityTarget.centerPoint, windowId: windowId, preferredWindow: accessibilityTarget.containerView.window) {
+                return editableAncestor(for: hitView)
+            }
+            return nil
+        case .point(let point):
+            if let hitView = hitView(at: point, windowId: windowId, preferredWindow: nil) {
                 return editableAncestor(for: hitView)
             }
             return nil

--- a/iOS/Sources/AppReveal/MCPServer/MCPTools.swift
+++ b/iOS/Sources/AppReveal/MCPServer/MCPTools.swift
@@ -639,6 +639,8 @@ private func registerIOSBuiltInTools() {
                 InteractionEngine.shared.tap(point: center, windowId: windowId)
             case .accessibility(let accessibilityTarget):
                 InteractionEngine.shared.tap(point: accessibilityTarget.centerPoint, windowId: windowId)
+            case .point(let point):
+                InteractionEngine.shared.tap(point: point, windowId: windowId)
             }
             return AnyCodable(["success": true, "text": text] as [String: Any])
         }


### PR DESCRIPTION
## Summary

- **Root cause**: On iOS 26, `_UIHostingView.accessibilityElementCount()` returns 0 when VoiceOver is off — SwiftUI defers building its accessibility tree until a real assistive technology is running. AppReveal's in-process scan cannot trigger that build, so SwiftUI buttons were invisible to `get_elements` regardless of `.accessibilityIdentifier()`.
- **Fix**: new `SwiftUIElementRegistry` + `.appReveal("id")` opt-in `ViewModifier` that tracks element frames via `PreferenceKey` (no private APIs, no accessibility APIs). Registered elements appear in `get_elements` with `idSource: "appReveal"` and are tapped via the existing SwiftUI-aware HID path.
- **Also fixed**: `enumerateAccessibilitySubelements` count/index fallback for SwiftUI virtual accessibility proxy nodes (helps on iOS < 26 / when VoiceOver is on), trait-based `resolveId` for unlabeled elements, version constant `0.9.3 → 0.9.7`.

## Changes

- `iOS/Sources/AppReveal/Elements/SwiftUIElementRegistry.swift` (new) — registry + `PreferenceKey` + `ViewModifier` + `public extension View { func appReveal(...) }`
- `ElementInventory.swift` — `appendSwiftUIRegisteredElements` wired into `listElements()` and `findTapTarget(byId:)`
- `AccessibilityElementInventory.swift` — `TapTarget.point(CGPoint)` case; `enumerateAccessibilitySubelements` count/index fallback; trait-based `resolveId`
- `InteractionEngine.swift` — `.point` delegates to `tap(point:)` for full SwiftUI/HID stack
- `MCPTools.swift` — `.point` exhaustive switch case for `tap_text` path
- `AppRevealVersion.swift` — `0.9.3 → 0.9.7`
- `example/iOS/.../TapCalibrationViewController.swift` — both SwiftUI test buttons annotated with `.appReveal()`; added `imageButtonResultLabel`
- `docs/ios.md` — documents iOS 26 limitation and `.appReveal()` usage pattern

## Test plan

- [x] Build succeeds (no errors, no warnings)
- [x] `get_elements` on Tap Calibration screen shows `calibration.swiftui_button` and `calibration.image_button` with `idSource: "appReveal"`
- [x] `tap_element("calibration.swiftui_button")` → result label shows "SwiftUI button tapped!"
- [x] `tap_element("calibration.image_button")` → result label shows "SwiftUI image button tapped!"
- [x] `initialize` serverInfo.version returns `0.9.7`
- [x] All linters pass

Closes #32.

🤖 Generated with [Claude Code](https://claude.com/claude-code)