### PR TITLE
fix(ios): focus SwiftUI TextField on tap (iOS 26)

### DIFF
--- a/example/iOS/AppRevealExample/Screens/TapCalibrationViewController.swift
+++ b/example/iOS/AppRevealExample/Screens/TapCalibrationViewController.swift
@@ -13,7 +13,7 @@ final class TapCalibrationViewController: UIViewController {
         title = "Tap Calibration"
         view.backgroundColor = .systemBackground
         setupViews()
-        embedSwiftUIButton()
+        embedSwiftUIView()
     }
 
     private func setupViews() {
@@ -68,7 +68,7 @@ final class TapCalibrationViewController: UIViewController {
         ])
     }
 
-    private func embedSwiftUIButton() {
+    private func embedSwiftUIView() {
         let swiftUIVC = UIHostingController(rootView: SwiftUITapTestView(
             onTap: { [weak self] in self?.swiftUIButtonTapped() },
             onImageTap: { [weak self] in self?.swiftUIImageButtonTapped() }
@@ -82,7 +82,7 @@ final class TapCalibrationViewController: UIViewController {
             swiftUIVC.view.topAnchor.constraint(equalTo: imageButtonResultLabel.bottomAnchor, constant: 16),
             swiftUIVC.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             swiftUIVC.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            swiftUIVC.view.heightAnchor.constraint(equalToConstant: 130)
+            swiftUIVC.view.heightAnchor.constraint(equalToConstant: 180)
         ])
     }
 
@@ -115,6 +115,8 @@ private struct SwiftUITapTestView: View {
     let onTap: () -> Void
     let onImageTap: () -> Void
 
+    @State private var textFieldValue = ""
+
     var body: some View {
         VStack(spacing: 8) {
             Text("SwiftUI Button Test")
@@ -145,6 +147,16 @@ private struct SwiftUITapTestView: View {
                 #endif
             }
             .padding(.horizontal, 24)
+
+            // SwiftUI TextField for iOS 26 tap-to-focus verification.
+            // tap_point on this field should bring up the keyboard (type_text should then work).
+            TextField("Type here (SwiftUI)", text: $textFieldValue)
+                .textFieldStyle(.roundedBorder)
+                .padding(.horizontal, 24)
+                .accessibilityIdentifier("calibration.swiftui_field")
+                #if DEBUG
+                .appReveal("calibration.swiftui_field", label: "Type here (SwiftUI)")
+                #endif
         }
     }
 }

--- a/iOS/Sources/AppReveal/AppRevealVersion.swift
+++ b/iOS/Sources/AppReveal/AppRevealVersion.swift
@@ -2,5 +2,5 @@
 // Update this constant on every release to match the git tag.
 
 enum AppRevealVersion {
-    static let current = "0.9.7"
+    static let current = "0.9.8"
 }

--- a/iOS/Sources/AppReveal/Interaction/InteractionEngine.swift
+++ b/iOS/Sources/AppReveal/Interaction/InteractionEngine.swift
@@ -107,6 +107,14 @@ final class InteractionEngine {
             let isSwiftUIHost = hitView.map { Self.isSwiftUIHostingView($0) } ?? false
 
             if isSwiftUIHost, let hostingView = hitView {
+                // On iOS 26, synthetic taps reach SwiftUI Button gesture recognizers but do
+                // NOT propagate through SwiftUI's focus system to make a TextField become
+                // first responder. Check for an editable UITextField/UITextView at the tap
+                // point first — if found, activate it directly and skip the gesture path.
+                if let textInput = findEditableView(at: point, in: hostingView) {
+                    textInput.becomeFirstResponder()
+                    return true
+                }
                 let axTarget = AccessibilityElementInventory.shared.findElement(at: point, in: window)
                 if let accessibilityTarget = axTarget, accessibilityTarget.activate() {
                     return true
@@ -177,6 +185,23 @@ final class InteractionEngine {
         // so check with contains rather than hasPrefix on a stripped base component.
         let name = Swift.type(of: view).description()
         return name.contains("_UIHostingView") || name.contains("UIHostingView")
+    }
+
+    // Find a UITextField or UITextView inside a SwiftUI hosting view whose frame
+    // in window coordinates contains the given point. SwiftUI renders TextFields as
+    // real UITextField instances in the hosting view's subview tree.
+    private func findEditableView(at windowPoint: CGPoint, in root: UIView) -> UIView? {
+        let frameInWindow = root.convert(root.bounds, to: nil)
+        guard frameInWindow.contains(windowPoint) else { return nil }
+        if root is UITextField || root is UITextView {
+            return root
+        }
+        for subview in root.subviews where !subview.isHidden {
+            if let found = findEditableView(at: windowPoint, in: subview) {
+                return found
+            }
+        }
+        return nil
     }
 
     // Delivers a tap to a SwiftUI hosting view.
@@ -370,6 +395,16 @@ final class InteractionEngine {
         guard let view else { return false }
 
         if let control = findAncestorControl(from: view) {
+            // UITextField/UITextView respond to tap by becoming first responder.
+            // sendActions(for:) does not trigger focus — call becomeFirstResponder directly.
+            if let textInput = control as? UITextField {
+                textInput.becomeFirstResponder()
+                return true
+            }
+            if let textInput = control as? UITextView {
+                textInput.becomeFirstResponder()
+                return true
+            }
             control.sendActions(for: .touchUpInside)
             return true
         }


### PR DESCRIPTION
## Summary

- On iOS 26, synthetic tap events (IOHIDDigitizerEvent) fire SwiftUI Button actions but do **not** propagate through SwiftUI's focus system to make a TextField become first responder. `type_text` always failed with `"current responder not editable"`.
- `sendActions(for: .touchUpInside)` on a `UITextField` also does not trigger focus — the correct call is `becomeFirstResponder()`.

## Changes

**`iOS/Sources/AppReveal/Interaction/InteractionEngine.swift`:**

1. `performTap(onView:at:)` — when `findAncestorControl` returns a `UITextField` or `UITextView`, call `becomeFirstResponder()` instead of `sendActions(for: .touchUpInside)`. Fixes `tap_element` → `type_text` for both UIKit TextFields and SwiftUI TextFields (which are backed by a real `UITextField` in the view hierarchy, found via the standard UIKit walk).

2. `tap(point:)` SwiftUI hosting view path — new `findEditableView(at:in:)` walks the hosting view's subview tree to find a `UITextField`/`UITextView` at the tap point. If found, calls `becomeFirstResponder()` before attempting the gesture/HID path. Fixes `tap_point` on a SwiftUI TextField when the hit view is the hosting view.

**`example/iOS/.../TapCalibrationViewController.swift`** — added SwiftUI TextField for end-to-end verification.

## Test plan

Verified on iPhone 17 Pro (iOS 26.2 Simulator):
- [x] `tap_element("type_here_swiftui")` → `{"success":true}` → keyboard appears
- [x] `type_text("hello world")` → `{"success":true, "text":"hello world"}`
- [x] `tap_point(x:201, y:569)` (TextField center) → keyboard appears
- [x] `type_text("from tap_point")` → `{"success":true}`
- [x] `tap_element("calibration.swiftui_button")` still works (regression check)
- [x] `tap_element("calibration.image_button")` still works (regression check)
- [x] All linters pass

Closes #34.

🤖 Generated with [Claude Code](https://claude.com/claude-code)