### PR TITLE
Fix Android Compose semantics automation

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
       - run: cd iOS && swiftlint lint --strict
 
   android:
-    name: ktlint (Android)
+    name: Build and lint (Android)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -24,7 +24,8 @@ jobs:
           distribution: temurin
           java-version: 17
       - uses: android-actions/setup-android@v3
-      - run: cd Android && chmod +x gradlew && ./gradlew ktlintCheck
+      - run: cd Android && chmod +x gradlew && ./gradlew ktlintCheck :appreveal:assembleDebug :appreveal:lintDebug
+      - run: cd example/Android && chmod +x gradlew && ./gradlew :app:assembleDebug
 
   flutter:
     name: dart analyze (Flutter)

--- a/Android/appreveal/src/main/kotlin/com/appreveal/elements/ComposeElementInventory.kt
+++ b/Android/appreveal/src/main/kotlin/com/appreveal/elements/ComposeElementInventory.kt
@@ -4,79 +4,298 @@ import android.graphics.Rect
 import android.os.Bundle
 import android.view.View
 import android.view.ViewGroup
+import android.view.accessibility.AccessibilityNodeInfo
 import androidx.core.graphics.Insets
 import androidx.core.view.ViewCompat
 import androidx.core.view.WindowInsetsCompat
 import androidx.core.view.accessibility.AccessibilityNodeInfoCompat
+import androidx.core.view.accessibility.AccessibilityNodeProviderCompat
 import kotlin.math.max
 import kotlin.math.min
 
+/** Result of trying to edit a Compose semantics node. */
+internal enum class ComposeTextActionResult {
+    SUCCESS,
+    NOT_FOUND,
+    NOT_EDITABLE,
+    ACTION_FAILED,
+}
+
+/** A text match and the semantics action that should receive its tap. */
+internal data class ComposeTextMatch(
+    val matchedText: String,
+    internal val action: Any?,
+    internal val provider: AccessibilityNodeProviderCompat?,
+    internal val actionNodeId: Int?,
+)
+
 /**
- * Traverses Jetpack Compose UI trees via the accessibility node provider.
+ * Traverses Jetpack Compose through its semantics tree without taking a Compose dependency.
  *
- * Compose renders its entire UI into a single AndroidComposeView (a custom View subclass).
- * Individual composables are NOT Android Views; they live in Compose's internal node tree.
- * However, Compose implements AccessibilityNodeProvider so TalkBack can read them — we use
- * the same API to enumerate and interact with composables without reflection or Compose deps.
+ * Accessibility nodes created in the app process cannot safely recurse with `getChild()` on
+ * Android 26-33. Instead, this bridge reflects the stable JVM-facing semantics accessors on
+ * AndroidComposeView, then asks the view's accessibility provider for each known semantics ID.
+ * Actions invoke the node's semantics callback directly, with the accessibility provider retained
+ * as a fallback when Android accessibility is active.
  */
 internal object ComposeElementInventory {
-    fun listElements(root: View): List<ElementInfo> {
-        val results = mutableListOf<ElementInfo>()
-        val seenIds = mutableMapOf<String, Int>()
+    fun listElements(
+        root: View,
+        seenIds: MutableMap<String, Int>,
+    ): List<ElementInfo> = snapshot(root, seenIds).map { it.elementInfo }
+
+    fun tapElementById(
+        root: View,
+        id: String,
+        seenIds: MutableMap<String, Int>,
+    ): Boolean? {
+        val handle = snapshot(root, seenIds).firstOrNull { it.elementInfo.id == id } ?: return null
+        if (!handle.clickable) return false
+        if (invokeSemanticsAction(handle.clickAction)) return true
+        return handle.provider?.performAction(handle.semanticsId, AccessibilityNodeInfo.ACTION_CLICK, null) ?: false
+    }
+
+    fun findTextMatches(
+        root: View,
+        text: String,
+        matchMode: String,
+        seenIds: MutableMap<String, Int>,
+    ): List<ComposeTextMatch> {
+        val handles = snapshot(root, seenIds)
+        val handlesByNodeId = handles.associateBy { it.semanticsId }
+
+        return handles.mapNotNull { handle ->
+            val matchedText =
+                handle.searchableTexts.firstOrNull { candidate ->
+                    when (matchMode) {
+                        "contains" -> candidate.contains(text, ignoreCase = true)
+                        else -> candidate.equals(text, ignoreCase = true)
+                    }
+                } ?: return@mapNotNull null
+
+            var actionHandle: NodeHandle? = handle
+            while (actionHandle != null && !actionHandle.clickable) {
+                actionHandle = actionHandle.parentSemanticsId?.let(handlesByNodeId::get)
+            }
+
+            ComposeTextMatch(
+                matchedText = matchedText,
+                action = actionHandle?.clickAction,
+                provider = actionHandle?.provider,
+                actionNodeId = actionHandle?.semanticsId,
+            )
+        }
+    }
+
+    fun tapTextMatch(match: ComposeTextMatch): Boolean {
+        if (invokeSemanticsAction(match.action)) return true
+        val provider = match.provider ?: return false
+        val nodeId = match.actionNodeId ?: return false
+        return provider.performAction(nodeId, AccessibilityNodeInfo.ACTION_CLICK, null)
+    }
+
+    fun typeTextById(
+        root: View,
+        id: String,
+        text: String,
+        append: Boolean,
+        seenIds: MutableMap<String, Int>,
+    ): ComposeTextActionResult {
+        val handle =
+            snapshot(root, seenIds).firstOrNull { it.elementInfo.id == id }
+                ?: return ComposeTextActionResult.NOT_FOUND
+        return setText(handle, text, append)
+    }
+
+    fun typeTextInFocusedElement(
+        root: View,
+        text: String,
+        append: Boolean,
+        seenIds: MutableMap<String, Int>,
+    ): ComposeTextActionResult {
+        val handle =
+            snapshot(root, seenIds).firstOrNull { it.focused && it.editable }
+                ?: return ComposeTextActionResult.NOT_FOUND
+        return setText(handle, text, append)
+    }
+
+    fun dumpTreeForComposeView(
+        composeView: View,
+        depth: Int,
+        maxDepth: Int,
+    ): List<Map<String, Any>> {
+        if (!isComposeView(composeView) || depth >= maxDepth) return emptyList()
+        val provider = ViewCompat.getAccessibilityNodeProvider(composeView)
+        val rootNode = semanticsRootFor(composeView) ?: return emptyList()
+        val result = mutableListOf<Map<String, Any>>()
+        dumpSemanticsNode(rootNode, composeView, provider, depth, maxDepth, result)
+        return result
+    }
+
+    fun isComposeView(view: View): Boolean = view.javaClass.name.contains("AndroidComposeView")
+
+    private data class NodeHandle(
+        val semanticsId: Int,
+        val parentSemanticsId: Int?,
+        val provider: AccessibilityNodeProviderCompat?,
+        val elementInfo: ElementInfo,
+        val searchableTexts: List<String>,
+        val editable: Boolean,
+        val focused: Boolean,
+        val clickable: Boolean,
+        val currentText: String?,
+        val editableTextTemplate: Any?,
+        val clickAction: Any?,
+        val setTextAction: Any?,
+    )
+
+    private data class SemanticsProperties(
+        var testTag: String? = null,
+        var visibleText: List<String> = emptyList(),
+        var editableText: String? = null,
+        var contentDescriptions: List<String> = emptyList(),
+        var role: String? = null,
+        var hasOnClick: Boolean = false,
+        var hasSetText: Boolean = false,
+        var disabled: Boolean = false,
+        var focused: Boolean = false,
+        var invisibleToUser: Boolean = false,
+        var scrollable: Boolean = false,
+        var editableTextTemplate: Any? = null,
+        var clickAction: Any? = null,
+        var setTextAction: Any? = null,
+    ) {
+        val searchableTexts: List<String>
+            get() = (contentDescriptions + visibleText + listOfNotNull(editableText)).filter { it.isNotBlank() }.distinct()
+    }
+
+    private fun snapshot(
+        root: View,
+        seenIds: MutableMap<String, Int>,
+    ): List<NodeHandle> {
+        val results = mutableListOf<NodeHandle>()
         forEachComposeView(root) { composeView ->
-            traverseProviderTree(composeView, results, seenIds)
+            val semanticsRoot = semanticsRootFor(composeView) ?: return@forEachComposeView
+            val provider = ViewCompat.getAccessibilityNodeProvider(composeView)
+            walkSemanticsNode(
+                node = semanticsRoot,
+                composeView = composeView,
+                provider = provider,
+                parentSemanticsId = null,
+                containerId = null,
+                seenIds = seenIds,
+                results = results,
+            )
         }
         return results
     }
 
-    fun findElementById(
-        root: View,
-        id: String,
-    ): AccessibilityNodeInfoCompat? {
-        var found: AccessibilityNodeInfoCompat? = null
-        val seenIds = mutableMapOf<String, Int>()
-        forEachComposeView(root) { composeView ->
-            if (found != null) return@forEachComposeView
-            val rootNode = rootNodeFor(composeView) ?: return@forEachComposeView
-            found = findNodeById(rootNode, id, seenIds, composeView)
+    private fun walkSemanticsNode(
+        node: Any,
+        composeView: View,
+        provider: AccessibilityNodeProviderCompat?,
+        parentSemanticsId: Int?,
+        containerId: String?,
+        seenIds: MutableMap<String, Int>,
+        results: MutableList<NodeHandle>,
+    ) {
+        val semanticsId = semanticsId(node) ?: return
+        val properties = semanticsProperties(node)
+        val accessibilityInfo = createAccessibilityNodeInfo(provider, semanticsId)
+        val bounds = boundsFor(node, composeView, accessibilityInfo)
+        val visible =
+            !properties.invisibleToUser &&
+                (accessibilityInfo?.isVisibleToUser ?: (composeView.isShown && !bounds.isEmpty))
+        val clickable = properties.hasOnClick || accessibilityInfo?.isClickable == true
+        val editable = properties.hasSetText || accessibilityInfo?.isEditable == true
+        val label =
+            properties.contentDescriptions.firstOrNull()
+                ?: properties.visibleText.firstOrNull()
+                ?: accessibilityInfo?.contentDescription?.toString()?.takeIf { it.isNotBlank() }
+                ?: accessibilityInfo?.text?.toString()?.takeIf { it.isNotBlank() }
+        val currentText =
+            properties.editableText
+                ?: accessibilityInfo?.text?.toString()?.takeIf { it.isNotBlank() }
+        val shouldList = visible && !bounds.isEmpty && (properties.testTag != null || label != null || clickable || editable)
+
+        var currentContainerId = containerId
+        if (shouldList) {
+            val rawId = nodeId(semanticsId, properties, accessibilityInfo, label)
+            val finalId = deduplicatedId(rawId.first, seenIds)
+            val frame = bounds.toElementFrame()
+            val systemInsets = systemSafeAreaInsets(composeView)
+            val enabled = !properties.disabled && (accessibilityInfo?.isEnabled ?: true)
+            val actions = nodeActions(properties, accessibilityInfo, clickable, editable)
+            val elementInfo =
+                ElementInfo(
+                    id = finalId,
+                    type = classifyNode(properties, accessibilityInfo, editable, clickable),
+                    label = label,
+                    value = currentText?.takeIf { it != label },
+                    enabled = enabled,
+                    visible = visible,
+                    tappable = clickable,
+                    frame = frame,
+                    safeAreaInsets = safeAreaInsets(composeView, systemInsets),
+                    safeAreaLayoutGuideFrame = safeAreaLayoutGuideFrame(frame, composeView, systemInsets),
+                    containerId = containerId,
+                    actions = actions,
+                    idSource = rawId.second,
+                )
+            results.add(
+                NodeHandle(
+                    semanticsId = semanticsId,
+                    parentSemanticsId = parentSemanticsId,
+                    provider = provider,
+                    elementInfo = elementInfo,
+                    searchableTexts = properties.searchableTexts.ifEmpty { listOfNotNull(label, currentText) }.distinct(),
+                    editable = editable,
+                    focused = properties.focused || accessibilityInfo?.isFocused == true,
+                    clickable = clickable,
+                    currentText = currentText,
+                    editableTextTemplate = properties.editableTextTemplate,
+                    clickAction = properties.clickAction,
+                    setTextAction = properties.setTextAction,
+                ),
+            )
+            currentContainerId = finalId
         }
-        return found
+
+        semanticsChildren(node).forEach { child ->
+            walkSemanticsNode(
+                node = child,
+                composeView = composeView,
+                provider = provider,
+                parentSemanticsId = if (shouldList) semanticsId else parentSemanticsId,
+                containerId = currentContainerId,
+                seenIds = seenIds,
+                results = results,
+            )
+        }
     }
 
-    fun findNodeByText(
-        root: View,
+    private fun setText(
+        handle: NodeHandle,
         text: String,
-        matchMode: String,
-        occurrence: Int,
-    ): AccessibilityNodeInfoCompat? {
-        val candidates = mutableListOf<AccessibilityNodeInfoCompat>()
-        forEachComposeView(root) { composeView ->
-            val rootNode = rootNodeFor(composeView) ?: return@forEachComposeView
-            collectNodesByText(rootNode, text, matchMode, candidates)
+        append: Boolean,
+    ): ComposeTextActionResult {
+        if (!handle.editable) return ComposeTextActionResult.NOT_EDITABLE
+        val replacement = if (append) handle.currentText.orEmpty() + text else text
+        val annotatedString = annotatedString(handle.editableTextTemplate, replacement)
+        if (annotatedString != null && invokeSemanticsAction(handle.setTextAction, annotatedString)) {
+            return ComposeTextActionResult.SUCCESS
         }
-        return candidates.getOrNull(occurrence)
-    }
-
-    fun findNodeAtPoint(
-        root: View,
-        x: Float,
-        y: Float,
-    ): AccessibilityNodeInfoCompat? {
-        var best: AccessibilityNodeInfoCompat? = null
-        var bestArea = Long.MAX_VALUE
-        forEachComposeView(root) { composeView ->
-            val rootNode = rootNodeFor(composeView) ?: return@forEachComposeView
-            findNodeAtPoint(rootNode, x.toInt(), y.toInt()) { node, area ->
-                if (area < bestArea) {
-                    bestArea = area
-                    best = node
-                }
+        val provider = handle.provider ?: return ComposeTextActionResult.ACTION_FAILED
+        val arguments =
+            Bundle().apply {
+                putCharSequence(AccessibilityNodeInfo.ACTION_ARGUMENT_SET_TEXT_CHARSEQUENCE, replacement)
             }
+        return if (provider.performAction(handle.semanticsId, AccessibilityNodeInfo.ACTION_SET_TEXT, arguments)) {
+            ComposeTextActionResult.SUCCESS
+        } else {
+            ComposeTextActionResult.ACTION_FAILED
         }
-        return best
     }
-
-    // MARK: - Private
 
     private fun forEachComposeView(
         root: View,
@@ -87,186 +306,304 @@ internal object ComposeElementInventory {
             return
         }
         if (root is ViewGroup) {
-            for (i in 0 until root.childCount) {
-                forEachComposeView(root.getChildAt(i), action)
+            for (index in 0 until root.childCount) {
+                forEachComposeView(root.getChildAt(index), action)
             }
         }
     }
 
-    private fun isComposeView(view: View): Boolean = view.javaClass.name.contains("AndroidComposeView")
-
-    private fun rootNodeFor(composeView: View): AccessibilityNodeInfoCompat? {
-        val provider = ViewCompat.getAccessibilityNodeProvider(composeView) ?: return null
-        return provider.createAccessibilityNodeInfo(View.NO_ID)
+    private fun semanticsRootFor(composeView: View): Any? {
+        val owner = invokeNoArg(composeView, "getSemanticsOwner") ?: return null
+        return invokeNoArg(owner, "getRootSemanticsNode")
     }
 
-    private fun traverseProviderTree(
-        composeView: View,
-        results: MutableList<ElementInfo>,
-        seenIds: MutableMap<String, Int>,
-    ) {
-        val rootNode = rootNodeFor(composeView) ?: return
-        walkNode(rootNode, composeView, results, seenIds, containerId = null)
+    private fun semanticsId(node: Any): Int? = (invokeNoArg(node, "getId") as? Number)?.toInt()
+
+    private fun semanticsChildren(node: Any): List<Any> {
+        val children = invokeNoArg(node, "getChildren") as? Iterable<*> ?: return emptyList()
+        return children.filterNotNull()
     }
 
-    private fun walkNode(
-        node: AccessibilityNodeInfoCompat,
-        composeView: View,
-        results: MutableList<ElementInfo>,
-        seenIds: MutableMap<String, Int>,
-        containerId: String?,
-    ) {
-        val label = nodeLabel(node)
-        val isClickable = node.isClickable
-        val isEditable = node.isEditable
-        val isEnabled = node.isEnabled
-        val isVisible = node.isVisibleToUser
-
-        if (!isVisible) return
-
-        if (label != null || isClickable || isEditable) {
-            val rect = Rect()
-            node.getBoundsInScreen(rect)
-
-            if (!rect.isEmpty) {
-                val rawId = nodeId(node, label)
-                val finalId = deduplicatedId(rawId, seenIds)
-                val frame =
-                    ElementInfo.ElementFrame(
-                        x = rect.left.toDouble(),
-                        y = rect.top.toDouble(),
-                        width = rect.width().toDouble(),
-                        height = rect.height().toDouble(),
-                    )
-                val systemInsets = systemSafeAreaInsets(composeView)
-
-                results.add(
-                    ElementInfo(
-                        id = finalId,
-                        type = classifyNode(node),
-                        label = label,
-                        value = nodeValue(node),
-                        enabled = isEnabled,
-                        visible = isVisible,
-                        tappable = isClickable,
-                        frame = frame,
-                        safeAreaInsets = safeAreaInsets(composeView, systemInsets),
-                        safeAreaLayoutGuideFrame = safeAreaLayoutGuideFrame(frame, composeView, systemInsets),
-                        containerId = containerId,
-                        actions = nodeActions(node),
-                        idSource = nodeIdSource(node),
-                    ),
-                )
-            }
-        }
-
-        val currentContainerId = nodeId(node, label).takeIf { label != null } ?: containerId
-        for (i in 0 until node.childCount) {
-            val child = node.getChild(i) ?: continue
-            walkNode(child, composeView, results, seenIds, currentContainerId)
-        }
-    }
-
-    private fun findNodeById(
-        node: AccessibilityNodeInfoCompat,
-        targetId: String,
-        seenIds: MutableMap<String, Int>,
-        composeView: View,
-    ): AccessibilityNodeInfoCompat? {
-        val label = nodeLabel(node)
-        val rawId = nodeId(node, label)
-        val finalId = deduplicatedId(rawId, seenIds.toMutableMap())
-
-        if (finalId == targetId || rawId == targetId) return node
-
-        for (i in 0 until node.childCount) {
-            val child = node.getChild(i) ?: continue
-            val found = findNodeById(child, targetId, seenIds, composeView)
-            if (found != null) return found
-        }
-        return null
-    }
-
-    private fun collectNodesByText(
-        node: AccessibilityNodeInfoCompat,
-        text: String,
-        matchMode: String,
-        results: MutableList<AccessibilityNodeInfoCompat>,
-    ) {
-        val label = nodeLabel(node)
-        if (label != null) {
-            val isMatch =
-                when (matchMode) {
-                    "contains" -> label.contains(text, ignoreCase = true)
-                    else -> label.equals(text, ignoreCase = false)
+    private fun semanticsProperties(node: Any): SemanticsProperties {
+        val properties = SemanticsProperties()
+        val config = invokeNoArg(node, "getConfig") as? Iterable<*> ?: return properties
+        config.forEach { item ->
+            val entry = item as? Map.Entry<*, *> ?: return@forEach
+            val key = entry.key ?: return@forEach
+            val name = invokeNoArg(key, "getName") as? String ?: return@forEach
+            val value = entry.value
+            when (name) {
+                "TestTag" -> properties.testTag = value?.toString()?.takeIf { it.isNotBlank() }
+                "Text" -> properties.visibleText = semanticsTextList(value)
+                "EditableText" -> {
+                    properties.editableText = value?.toString()
+                    properties.editableTextTemplate = value
                 }
-            if (isMatch && node.isClickable) {
-                results.add(node)
+                "ContentDescription" -> properties.contentDescriptions = semanticsTextList(value)
+                "Role" -> properties.role = value?.toString()
+                "OnClick" -> {
+                    properties.hasOnClick = true
+                    properties.clickAction = accessibilityAction(value)
+                }
+                "SetText" -> {
+                    properties.hasSetText = true
+                    properties.setTextAction = accessibilityAction(value)
+                }
+                "Disabled" -> properties.disabled = true
+                "Focused" -> properties.focused = value as? Boolean ?: false
+                "InvisibleToUser", "HideFromAccessibility" -> properties.invisibleToUser = true
+                "ScrollBy", "ScrollToIndex", "HorizontalScrollAxisRange", "VerticalScrollAxisRange" -> {
+                    properties.scrollable = true
+                }
             }
         }
-        for (i in 0 until node.childCount) {
-            collectNodesByText(node.getChild(i) ?: continue, text, matchMode, results)
+        return properties
+    }
+
+    private fun semanticsTextList(value: Any?): List<String> =
+        when (value) {
+            is Iterable<*> -> value.mapNotNull { it?.toString()?.takeIf(String::isNotBlank) }
+            null -> emptyList()
+            else -> listOf(value.toString()).filter(String::isNotBlank)
+        }
+
+    private fun invokeNoArg(
+        target: Any,
+        methodName: String,
+    ): Any? =
+        try {
+            target.javaClass.methods
+                .firstOrNull { it.name == methodName && it.parameterCount == 0 }
+                ?.invoke(target)
+        } catch (_: ReflectiveOperationException) {
+            null
+        } catch (_: RuntimeException) {
+            null
+        }
+
+    private fun accessibilityAction(value: Any?): Any? = value?.let { invokeNoArg(it, "getAction") }
+
+    private fun invokeSemanticsAction(
+        action: Any?,
+        argument: Any? = null,
+    ): Boolean {
+        if (action == null) return false
+        return try {
+            val parameterCount = if (argument == null) 0 else 1
+            val method =
+                action.javaClass.methods.firstOrNull {
+                    it.name == "invoke" && it.parameterCount == parameterCount && !it.isBridge
+                } ?: action.javaClass.methods.firstOrNull {
+                    it.name == "invoke" && it.parameterCount == parameterCount
+                } ?: return false
+            val result = if (argument == null) method.invoke(action) else method.invoke(action, argument)
+            result as? Boolean ?: false
+        } catch (_: ReflectiveOperationException) {
+            false
+        } catch (_: RuntimeException) {
+            false
         }
     }
 
-    private fun findNodeAtPoint(
-        node: AccessibilityNodeInfoCompat,
-        x: Int,
-        y: Int,
-        visitor: (AccessibilityNodeInfoCompat, Long) -> Unit,
-    ) {
-        if (!node.isVisibleToUser) return
-        val rect = Rect()
-        node.getBoundsInScreen(rect)
-        if (rect.contains(x, y) && node.isClickable) {
-            visitor(node, rect.width().toLong() * rect.height().toLong())
-        }
-        for (i in 0 until node.childCount) {
-            findNodeAtPoint(node.getChild(i) ?: continue, x, y, visitor)
+    private fun annotatedString(
+        template: Any?,
+        text: String,
+    ): Any? {
+        val type = template?.javaClass ?: return null
+        return try {
+            val constructor =
+                type.constructors
+                    .filter { candidate ->
+                        candidate.parameterTypes.firstOrNull() == String::class.java &&
+                            candidate.parameterTypes.drop(1).all { List::class.java.isAssignableFrom(it) }
+                    }
+                    .minByOrNull { it.parameterCount }
+                    ?: return null
+            val arguments = arrayOfNulls<Any>(constructor.parameterCount)
+            arguments[0] = text
+            for (index in 1 until arguments.size) arguments[index] = emptyList<Any>()
+            constructor.newInstance(*arguments)
+        } catch (_: ReflectiveOperationException) {
+            null
+        } catch (_: RuntimeException) {
+            null
         }
     }
 
-    // MARK: - Node attribute helpers
+    private fun createAccessibilityNodeInfo(
+        provider: AccessibilityNodeProviderCompat?,
+        semanticsId: Int,
+    ): AccessibilityNodeInfoCompat? =
+        try {
+            provider?.createAccessibilityNodeInfo(semanticsId)
+        } catch (_: RuntimeException) {
+            null
+        }
 
-    private fun nodeLabel(node: AccessibilityNodeInfoCompat): String? {
-        val desc = node.contentDescription?.toString()?.takeIf { it.isNotBlank() }
-        val text = node.text?.toString()?.takeIf { it.isNotBlank() }
-        return desc ?: text
-    }
+    private fun boundsFor(
+        node: Any,
+        composeView: View,
+        accessibilityInfo: AccessibilityNodeInfoCompat?,
+    ): Rect {
+        val accessibilityBounds = Rect()
+        accessibilityInfo?.getBoundsInScreen(accessibilityBounds)
+        if (!accessibilityBounds.isEmpty) return accessibilityBounds
 
-    private fun nodeValue(node: AccessibilityNodeInfoCompat): String? {
-        val text = node.text?.toString()?.takeIf { it.isNotBlank() }
-        val desc = node.contentDescription?.toString()?.takeIf { it.isNotBlank() }
-        return if (desc != null && text != null && desc != text) text else null
+        val composeBounds = invokeNoArg(node, "getBoundsInRoot") ?: return accessibilityBounds
+        val left = (invokeNoArg(composeBounds, "getLeft") as? Number)?.toFloat() ?: return accessibilityBounds
+        val top = (invokeNoArg(composeBounds, "getTop") as? Number)?.toFloat() ?: return accessibilityBounds
+        val right = (invokeNoArg(composeBounds, "getRight") as? Number)?.toFloat() ?: return accessibilityBounds
+        val bottom = (invokeNoArg(composeBounds, "getBottom") as? Number)?.toFloat() ?: return accessibilityBounds
+        val location = IntArray(2)
+        composeView.getLocationOnScreen(location)
+        return Rect(
+            (location[0] + left).toInt(),
+            (location[1] + top).toInt(),
+            (location[0] + right).toInt(),
+            (location[1] + bottom).toInt(),
+        )
     }
 
     private fun nodeId(
-        node: AccessibilityNodeInfoCompat,
+        semanticsId: Int,
+        properties: SemanticsProperties,
+        accessibilityInfo: AccessibilityNodeInfoCompat?,
         label: String?,
-    ): String {
-        val resId = node.viewIdResourceName?.substringAfterLast('/')?.takeIf { it.isNotBlank() }
-        return resId ?: ElementInventory.normalizeToId(label ?: node.className?.toString() ?: "compose_node")
+    ): Pair<String, String> {
+        properties.testTag?.let { return Pair(it, "explicit") }
+        accessibilityInfo?.viewIdResourceName
+            ?.substringAfterLast('/')
+            ?.takeIf { it.isNotBlank() }
+            ?.let { return Pair(it, "explicit") }
+        properties.contentDescriptions.firstOrNull()?.let {
+            return Pair(ElementInventory.normalizeToId(it), "semantics")
+        }
+        properties.visibleText.firstOrNull()?.let {
+            return Pair(ElementInventory.normalizeToId(it), "text")
+        }
+        properties.editableText?.takeIf { it.isNotBlank() }?.let {
+            return Pair(ElementInventory.normalizeToId(it), "text")
+        }
+        label?.let { return Pair(ElementInventory.normalizeToId(it), "text") }
+        return Pair("compose_$semanticsId", "derived")
     }
 
-    private fun nodeIdSource(node: AccessibilityNodeInfoCompat): String {
-        if (node.viewIdResourceName != null) return "explicit"
-        if (node.contentDescription != null) return "semantics"
-        if (node.text != null) return "text"
-        return "derived"
-    }
-
-    private fun classifyNode(node: AccessibilityNodeInfoCompat): ElementType {
-        val cls = node.className?.toString() ?: ""
+    private fun classifyNode(
+        properties: SemanticsProperties,
+        accessibilityInfo: AccessibilityNodeInfoCompat?,
+        editable: Boolean,
+        clickable: Boolean,
+    ): ElementType {
+        val className = accessibilityInfo?.className?.toString().orEmpty()
+        val role = properties.role.orEmpty()
         return when {
-            cls.contains("EditText") || node.isEditable -> ElementType.TEXT_FIELD
-            node.isClickable -> ElementType.BUTTON
-            cls.contains("Switch") -> ElementType.TOGGLE
-            cls.contains("Slider") || cls.contains("SeekBar") -> ElementType.SLIDER
-            cls.contains("CheckBox") -> ElementType.TOGGLE
-            cls.contains("RadioButton") -> ElementType.OTHER
+            editable || className.contains("EditText") -> ElementType.TEXT_FIELD
+            role.contains("Switch", ignoreCase = true) ||
+                role.contains("Checkbox", ignoreCase = true) ||
+                className.contains("Switch") ||
+                className.contains("CheckBox") -> ElementType.TOGGLE
+            role.contains("Image", ignoreCase = true) || className.contains("Image") -> ElementType.IMAGE
+            role.contains("Tab", ignoreCase = true) -> ElementType.OTHER
+            role.contains("Button", ignoreCase = true) || clickable -> ElementType.BUTTON
+            className.contains("Slider") || className.contains("SeekBar") -> ElementType.SLIDER
             else -> ElementType.LABEL
         }
     }
+
+    private fun nodeActions(
+        properties: SemanticsProperties,
+        accessibilityInfo: AccessibilityNodeInfoCompat?,
+        clickable: Boolean,
+        editable: Boolean,
+    ): List<String> {
+        val actions = mutableListOf<String>()
+        if (clickable) actions.add("tap")
+        if (accessibilityInfo?.isLongClickable == true) actions.add("longPress")
+        if (editable) {
+            actions.add("type")
+            actions.add("clear")
+        }
+        if (properties.scrollable || accessibilityInfo?.isScrollable == true) actions.add("scroll")
+        return actions
+    }
+
+    private fun dumpSemanticsNode(
+        node: Any,
+        composeView: View,
+        provider: AccessibilityNodeProviderCompat?,
+        depth: Int,
+        maxDepth: Int,
+        results: MutableList<Map<String, Any>>,
+    ) {
+        if (depth >= maxDepth) return
+        val semanticsId = semanticsId(node) ?: return
+        val properties = semanticsProperties(node)
+        val accessibilityInfo = createAccessibilityNodeInfo(provider, semanticsId)
+        val bounds = boundsFor(node, composeView, accessibilityInfo)
+        val label =
+            properties.contentDescriptions.firstOrNull()
+                ?: properties.visibleText.firstOrNull()
+                ?: accessibilityInfo?.contentDescription?.toString()?.takeIf { it.isNotBlank() }
+        val rawId = nodeId(semanticsId, properties, accessibilityInfo, label).first
+        val frame = bounds.toElementFrame()
+        val systemInsets = systemSafeAreaInsets(composeView)
+        val visible =
+            !properties.invisibleToUser &&
+                (accessibilityInfo?.isVisibleToUser ?: (composeView.isShown && !bounds.isEmpty))
+        val clickable = properties.hasOnClick || accessibilityInfo?.isClickable == true
+        val editable = properties.hasSetText || accessibilityInfo?.isEditable == true
+        val nodeMap =
+            mutableMapOf<String, Any>(
+                "class" to "Compose.${accessibilityInfo?.className?.toString()?.substringAfterLast('.') ?: "SemanticsNode"}",
+                "frame" to "${bounds.left},${bounds.top},${bounds.width()},${bounds.height()}",
+                "safeAreaInsets" to safeAreaInsets(composeView, systemInsets).toMap(),
+                "safeAreaLayoutGuideFrame" to safeAreaLayoutGuideFrame(frame, composeView, systemInsets).toMap(),
+                "hidden" to !visible,
+                "alpha" to 1.0f,
+                "userInteraction" to (clickable || editable),
+                "depth" to depth,
+                "virtual" to true,
+                "framework" to "compose",
+                "semanticsId" to semanticsId,
+                "accessibilityId" to rawId,
+                "enabled" to (!properties.disabled && (accessibilityInfo?.isEnabled ?: true)),
+                "focused" to (properties.focused || accessibilityInfo?.isFocused == true),
+                "editable" to editable,
+                "actions" to nodeActions(properties, accessibilityInfo, clickable, editable).joinToString(","),
+            )
+        label?.let { nodeMap["accessibilityLabel"] = it }
+        properties.visibleText.firstOrNull()?.let { nodeMap["text"] = it }
+        properties.editableText?.let { nodeMap["value"] = it }
+        results.add(nodeMap)
+
+        semanticsChildren(node).forEach { child ->
+            dumpSemanticsNode(child, composeView, provider, depth + 1, maxDepth, results)
+        }
+    }
+
+    private fun Rect.toElementFrame(): ElementInfo.ElementFrame =
+        ElementInfo.ElementFrame(
+            x = left.toDouble(),
+            y = top.toDouble(),
+            width = width().toDouble(),
+            height = height().toDouble(),
+        )
+
+    private fun ElementInfo.ElementInsets.toMap(): Map<String, Double> =
+        mapOf(
+            "top" to top,
+            "leading" to leading,
+            "bottom" to bottom,
+            "trailing" to trailing,
+        )
+
+    private fun ElementInfo.ElementFrame.toMap(): Map<String, Double> =
+        mapOf(
+            "x" to x,
+            "y" to y,
+            "width" to width,
+            "height" to height,
+        )
 
     private fun systemSafeAreaInsets(view: View): Insets =
         ViewCompat.getRootWindowInsets(view)
@@ -294,35 +631,20 @@ internal object ComposeElementInventory {
         val rootView = composeView.rootView ?: return frame
         val rootLocation = IntArray(2)
         rootView.getLocationOnScreen(rootLocation)
-
         val safeLeft = rootLocation[0].toDouble() + systemInsets.left
         val safeTop = rootLocation[1].toDouble() + systemInsets.top
         val safeRight = rootLocation[0].toDouble() + rootView.width - systemInsets.right
         val safeBottom = rootLocation[1].toDouble() + rootView.height - systemInsets.bottom
-
         val x = max(frame.x, safeLeft)
         val y = max(frame.y, safeTop)
         val right = min(frame.x + frame.width, safeRight)
         val bottom = min(frame.y + frame.height, safeBottom)
-
         return ElementInfo.ElementFrame(
             x = x,
             y = y,
             width = max(0.0, right - x),
             height = max(0.0, bottom - y),
         )
-    }
-
-    private fun nodeActions(node: AccessibilityNodeInfoCompat): List<String> {
-        val actions = mutableListOf<String>()
-        if (node.isClickable) actions.add("tap")
-        if (node.isLongClickable) actions.add("longPress")
-        if (node.isEditable) {
-            actions.add("type")
-            actions.add("clear")
-        }
-        if (node.isScrollable) actions.add("scroll")
-        return actions
     }
 
     private fun deduplicatedId(
@@ -333,9 +655,4 @@ internal object ComposeElementInventory {
         seenIds[id] = count + 1
         return if (count == 0) id else "${id}_$count"
     }
-}
-
-// Perform an accessibility action on a Compose node.
-internal fun AccessibilityNodeInfoCompat.clickCompose(): Boolean {
-    return performAction(AccessibilityNodeInfoCompat.ACTION_CLICK, Bundle())
 }

--- a/Android/appreveal/src/main/kotlin/com/appreveal/elements/ElementInventory.kt
+++ b/Android/appreveal/src/main/kotlin/com/appreveal/elements/ElementInventory.kt
@@ -23,6 +23,13 @@ import com.google.android.material.materialswitch.MaterialSwitch
 import kotlin.math.max
 import kotlin.math.min
 
+internal enum class ElementTextActionResult {
+    SUCCESS,
+    NOT_FOUND,
+    NOT_EDITABLE,
+    ACTION_FAILED,
+}
+
 /**
  * Enumerates visible interactive elements from the Android view hierarchy.
  */
@@ -34,7 +41,7 @@ internal object ElementInventory {
             val seenIds = mutableMapOf<String, Int>()
             walkView(decorView, elements, null, seenIds)
             // Append Compose semantics nodes for any AndroidComposeView in the hierarchy.
-            elements.addAll(ComposeElementInventory.listElements(decorView))
+            elements.addAll(ComposeElementInventory.listElements(decorView, seenIds))
             elements
         }
     }
@@ -49,22 +56,21 @@ internal object ElementInventory {
             if (view != null) {
                 if (view.isClickable || view.hasOnClickListeners()) {
                     view.performClick()
+                    return@runBlocking true
                 } else {
                     var parent: View? = view.parent as? View
                     while (parent != null) {
                         if (parent.isClickable || parent.hasOnClickListeners()) {
                             parent.performClick()
-                            break
+                            return@runBlocking true
                         }
                         parent = parent.parent as? View
                     }
                 }
-                return@runBlocking true
             }
             // Fall back to Compose accessibility node
             val decorView = ScreenResolver.currentActivity?.window?.decorView ?: return@runBlocking false
-            val node = ComposeElementInventory.findElementById(decorView, id) ?: return@runBlocking false
-            node.clickCompose()
+            ComposeElementInventory.tapElementById(decorView, id, composeSeenIds(decorView)) ?: false
         }
     }
 
@@ -85,36 +91,121 @@ internal object ElementInventory {
             val viewMatches = mutableListOf<Pair<View, String>>()
             collectTextMatches(decorView, text, matchMode, viewMatches)
 
-            // Compose match
-            val composeNode = ComposeElementInventory.findNodeByText(decorView, text, matchMode, occurrence)
+            // Compose matches share the same occurrence space and candidate list as Views.
+            val composeMatches =
+                ComposeElementInventory.findTextMatches(
+                    decorView,
+                    text,
+                    matchMode,
+                    composeSeenIds(decorView),
+                )
+            val candidates = viewMatches.map { it.second } + composeMatches.map { it.matchedText }
 
-            if (viewMatches.isEmpty() && composeNode == null) {
-                return@runBlocking mapOf("success" to false, "error" to "No element found with text: $text")
+            if (candidates.isEmpty()) {
+                return@runBlocking mapOf(
+                    "success" to false,
+                    "error" to "No element found with text: $text",
+                    "candidates" to candidates,
+                )
             }
 
-            if (composeNode != null && viewMatches.size <= occurrence) {
-                val clicked = composeNode.clickCompose()
-                return@runBlocking if (clicked) {
-                    mapOf("success" to true, "text" to text)
-                } else {
-                    mapOf("success" to false, "error" to "Compose action click failed for: $text")
-                }
-            }
-
-            if (occurrence >= viewMatches.size) {
+            if (occurrence !in candidates.indices) {
                 return@runBlocking mapOf(
                     "success" to false,
                     "error" to "occurrence $occurrence out of range",
-                    "candidates" to viewMatches.map { it.second },
+                    "candidates" to candidates,
                 )
+            }
+
+            if (occurrence >= viewMatches.size) {
+                val composeMatch = composeMatches[occurrence - viewMatches.size]
+                val clicked = ComposeElementInventory.tapTextMatch(composeMatch)
+                return@runBlocking if (clicked) {
+                    mapOf("success" to true, "text" to text, "candidates" to candidates)
+                } else {
+                    mapOf(
+                        "success" to false,
+                        "error" to "Compose action click failed for: $text",
+                        "candidates" to candidates,
+                    )
+                }
             }
 
             val (matchedView, _) = viewMatches[occurrence]
             val tappable = findTappableAncestor(matchedView) ?: matchedView
-            if (tappable.isClickable || tappable.hasOnClickListeners()) {
-                tappable.performClick()
+            if (!tappable.isClickable && !tappable.hasOnClickListeners()) {
+                return@runBlocking mapOf(
+                    "success" to false,
+                    "error" to "No tappable ancestor found for: $text",
+                    "candidates" to candidates,
+                )
             }
-            mapOf("success" to true, "text" to text)
+            tappable.performClick()
+            mapOf("success" to true, "text" to text, "candidates" to candidates)
+        }
+    }
+
+    fun typeText(
+        text: String,
+        elementId: String?,
+    ): ElementTextActionResult {
+        return MainThreadExecutor.runBlocking {
+            val decorView =
+                ScreenResolver.currentActivity?.window?.decorView
+                    ?: return@runBlocking ElementTextActionResult.NOT_FOUND
+
+            if (elementId != null) {
+                val view = findElement(elementId)
+                if (view is EditText) {
+                    view.requestFocus()
+                    view.append(text)
+                    return@runBlocking ElementTextActionResult.SUCCESS
+                }
+                if (view != null) return@runBlocking ElementTextActionResult.NOT_EDITABLE
+
+                return@runBlocking ComposeElementInventory.typeTextById(
+                    decorView,
+                    elementId,
+                    text,
+                    append = true,
+                    seenIds = composeSeenIds(decorView),
+                ).toElementResult()
+            }
+
+            val focusedView = ScreenResolver.currentActivity?.currentFocus
+            if (focusedView is EditText) {
+                focusedView.append(text)
+                return@runBlocking ElementTextActionResult.SUCCESS
+            }
+
+            ComposeElementInventory.typeTextInFocusedElement(
+                decorView,
+                text,
+                append = true,
+                seenIds = composeSeenIds(decorView),
+            ).toElementResult()
+        }
+    }
+
+    fun clearText(elementId: String): ElementTextActionResult {
+        return MainThreadExecutor.runBlocking {
+            val decorView =
+                ScreenResolver.currentActivity?.window?.decorView
+                    ?: return@runBlocking ElementTextActionResult.NOT_FOUND
+            val view = findElement(elementId)
+            if (view is EditText) {
+                view.setText("")
+                return@runBlocking ElementTextActionResult.SUCCESS
+            }
+            if (view != null) return@runBlocking ElementTextActionResult.NOT_EDITABLE
+
+            ComposeElementInventory.typeTextById(
+                decorView,
+                elementId,
+                text = "",
+                append = false,
+                seenIds = composeSeenIds(decorView),
+            ).toElementResult()
         }
     }
 
@@ -601,6 +692,9 @@ internal object ElementInventory {
         }
 
         val result = mutableListOf<Map<String, Any>>(node)
+        if (ComposeElementInventory.isComposeView(view)) {
+            result.addAll(ComposeElementInventory.dumpTreeForComposeView(view, depth + 1, maxDepth))
+        }
         if (view is ViewGroup) {
             for (i in 0 until view.childCount) {
                 result.addAll(dumpNode(view.getChildAt(i), depth + 1, maxDepth))
@@ -698,4 +792,18 @@ internal object ElementInventory {
         }
         return null
     }
+
+    private fun composeSeenIds(decorView: View): MutableMap<String, Int> {
+        val seenIds = mutableMapOf<String, Int>()
+        walkView(decorView, mutableListOf(), null, seenIds)
+        return seenIds
+    }
+
+    private fun ComposeTextActionResult.toElementResult(): ElementTextActionResult =
+        when (this) {
+            ComposeTextActionResult.SUCCESS -> ElementTextActionResult.SUCCESS
+            ComposeTextActionResult.NOT_FOUND -> ElementTextActionResult.NOT_FOUND
+            ComposeTextActionResult.NOT_EDITABLE -> ElementTextActionResult.NOT_EDITABLE
+            ComposeTextActionResult.ACTION_FAILED -> ElementTextActionResult.ACTION_FAILED
+        }
 }

--- a/Android/appreveal/src/main/kotlin/com/appreveal/interaction/InteractionEngine.kt
+++ b/Android/appreveal/src/main/kotlin/com/appreveal/interaction/InteractionEngine.kt
@@ -11,6 +11,7 @@ import androidx.activity.ComponentActivity
 import androidx.core.widget.NestedScrollView
 import androidx.recyclerview.widget.RecyclerView
 import com.appreveal.elements.ElementInventory
+import com.appreveal.elements.ElementTextActionResult
 import com.appreveal.screen.ScreenResolver
 import com.appreveal.shared.MainThreadExecutor
 import com.google.android.material.bottomnavigation.BottomNavigationView
@@ -71,43 +72,30 @@ internal object InteractionEngine {
         text: String,
         elementId: String?,
     ) {
-        MainThreadExecutor.runBlocking {
-            val target: View? =
+        when (ElementInventory.typeText(text, elementId)) {
+            ElementTextActionResult.SUCCESS -> Unit
+            ElementTextActionResult.NOT_FOUND -> {
                 if (elementId != null) {
-                    ElementInventory.findElement(elementId)
-                        ?: throw InteractionError.ElementNotFound(elementId)
+                    throw InteractionError.ElementNotFound(elementId)
                 } else {
-                    ScreenResolver.currentActivity?.currentFocus
+                    throw InteractionError.NotEditable("current focus")
                 }
-
-            when (target) {
-                is EditText -> {
-                    target.requestFocus()
-                    target.append(text)
-                }
-
-                else -> {
-                    throw InteractionError.NotEditable(elementId ?: "current focus")
-                }
+            }
+            ElementTextActionResult.NOT_EDITABLE -> {
+                throw InteractionError.NotEditable(elementId ?: "current focus")
+            }
+            ElementTextActionResult.ACTION_FAILED -> {
+                throw InteractionError.ActionFailed("type_text", elementId ?: "current focus")
             }
         }
     }
 
     fun clear(elementId: String) {
-        MainThreadExecutor.runBlocking {
-            val view =
-                ElementInventory.findElement(elementId)
-                    ?: throw InteractionError.ElementNotFound(elementId)
-
-            when (view) {
-                is EditText -> {
-                    view.setText("")
-                }
-
-                else -> {
-                    throw InteractionError.NotEditable(elementId)
-                }
-            }
+        when (ElementInventory.clearText(elementId)) {
+            ElementTextActionResult.SUCCESS -> Unit
+            ElementTextActionResult.NOT_FOUND -> throw InteractionError.ElementNotFound(elementId)
+            ElementTextActionResult.NOT_EDITABLE -> throw InteractionError.NotEditable(elementId)
+            ElementTextActionResult.ACTION_FAILED -> throw InteractionError.ActionFailed("clear_text", elementId)
         }
     }
 
@@ -294,6 +282,11 @@ sealed class InteractionError(
     class NotEditable(
         id: String,
     ) : InteractionError("Element not editable: $id")
+
+    class ActionFailed(
+        action: String,
+        id: String,
+    ) : InteractionError("$action action failed for: $id")
 
     class NotScrollable(
         id: String,

--- a/Android/appreveal/src/main/kotlin/com/appreveal/mcpserver/MCPTools.kt
+++ b/Android/appreveal/src/main/kotlin/com/appreveal/mcpserver/MCPTools.kt
@@ -3,6 +3,7 @@ package com.appreveal.mcpserver
 import android.content.Intent
 import android.net.Uri
 import android.os.Build
+import androidx.core.content.pm.PackageInfoCompat
 import com.appreveal.diagnostics.DiagnosticsBridge
 import com.appreveal.elements.ElementInventory
 import com.appreveal.interaction.InteractionEngine
@@ -645,7 +646,7 @@ internal fun registerBuiltInTools() {
                 JsonObject().apply {
                     addProperty("applicationId", packageName)
                     addProperty("versionName", packageInfo?.versionName ?: "unknown")
-                    addProperty("versionCode", packageInfo?.longVersionCode ?: 0L)
+                    addProperty("versionCode", packageInfo?.let(PackageInfoCompat::getLongVersionCode) ?: 0L)
                     addProperty("platform", "Android")
                     addProperty("systemVersion", Build.VERSION.RELEASE)
                     addProperty("deviceModel", Build.MODEL)
@@ -759,7 +760,7 @@ internal fun registerBuiltInTools() {
                     addProperty("appName", appInfo?.loadLabel(pm)?.toString() ?: "unknown")
                     addProperty("versionName", pkgInfo?.versionName ?: "unknown")
                     @Suppress("DEPRECATION")
-                    addProperty("versionCode", pkgInfo?.longVersionCode ?: 0L)
+                    addProperty("versionCode", pkgInfo?.let(PackageInfoCompat::getLongVersionCode) ?: 0L)
                     addProperty("targetSdk", appInfo?.targetSdkVersion ?: -1)
                     addProperty("minSdk", appInfo?.minSdkVersion ?: -1)
                     addProperty("firstInstallTime", pkgInfo?.firstInstallTime ?: 0L)

--- a/docs/android.md
+++ b/docs/android.md
@@ -96,6 +96,33 @@ Element IDs are resolved in this order:
 3. View tag: `view.tag` as String
 4. Content description: `view.contentDescription`
 
+#### Jetpack Compose
+
+Compose requires no additional AppReveal dependency or accessibility-service setup. AppReveal reads
+the merged semantics tree exposed by `AndroidComposeView`, so `get_elements`, `get_view_tree`,
+`tap_element`, `tap_text`, `type_text`, and `clear_text` work with Compose controls on API 26+.
+
+Use `Modifier.testTag` for stable IDs:
+
+```kotlin
+OutlinedTextField(
+    value = email,
+    onValueChange = { email = it },
+    modifier = Modifier.testTag("login.email"),
+)
+
+Button(
+    onClick = ::submit,
+    modifier = Modifier.testTag("login.submit"),
+) {
+    Text("Sign in")
+}
+```
+
+AppReveal reads `TestTag` directly; `testTagsAsResourceId` is not required. When a tag is absent,
+content descriptions and visible or editable text provide derived IDs. Compose actions are invoked
+through their semantics callbacks, so the feature does not depend on TalkBack being enabled.
+
 ### 4. Connect and use
 
 ```bash
@@ -167,11 +194,12 @@ interface NetworkObservable {
 
 - Transport: NanoHTTPD (embedded HTTP server)
 - Discovery: NsdManager (Android Network Service Discovery)
-- View hierarchy: ViewGroup tree walking
+- View hierarchy: ViewGroup walking plus dependency-free Jetpack Compose semantics traversal
 - Screenshots: PixelCopy (API 26+) / View.drawToBitmap
 - WebView: android.webkit.WebView + evaluateJavascript
 - Thread model: NanoHTTPD worker threads + MainThreadExecutor for UI access
 
 ## Example app
 
-See [`example/Android/`](../example/Android/) for a full example with 11 screens matching the iOS example, with all framework features integrated.
+See [`example/Android/`](../example/Android/) for a full example with View-based screens plus a
+Compose semantics fixture, with all framework features integrated.

--- a/example/Android/README.md
+++ b/example/Android/README.md
@@ -18,6 +18,7 @@ Example Android app demonstrating all AppReveal framework features.
 | `settings.main` | SettingsFragment | dark_mode, push_enabled, tap_calibration, delete_account |
 | `tap.calibration` | TapCalibrationFragment | status_card, summary, result, metrics, frame, target_01-target_24 |
 | `webview.demo` | WebViewDemoFragment | webview with interactive HTML page |
+| `compose.test` | ComposeActivity | tagged text field, tagged/text buttons, status labels, duplicate IDs |
 
 ## Element types covered
 
@@ -33,6 +34,7 @@ Example Android app demonstrating all AppReveal framework features.
 - SearchView (orders.search, catalog.search)
 - ImageView (login.logo, profile.avatar)
 - BottomNavigationView (5 tabs)
+- Jetpack Compose Text, OutlinedTextField, and Button semantics
 
 ## Framework features exercised
 
@@ -54,19 +56,33 @@ Example Android app demonstrating all AppReveal framework features.
 cd example/Android
 ./gradlew :app:installDebug
 adb shell am start -n com.appreveal.example/.MainActivity
+
+# Launch the dedicated Compose semantics fixture
+adb shell am start -n com.appreveal.example/.screens.ComposeActivity
 ```
 
 ## Connecting
 
 ```bash
-# Check logcat for the port
+# Check logcat for the dynamic port and session token
 adb logcat -s AppReveal
 
 # Forward port (emulator)
 adb forward tcp:56209 tcp:56209
 
+TOKEN="<session-token-from-logcat>"
+
 # Test MCP
 curl -X POST http://localhost:56209/ \
+  -H "Authorization: Bearer $TOKEN" \
   -H "Content-Type: application/json" \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
+```
+
+On the Compose fixture, verify `get_elements` and `get_view_tree`, then exercise
+`type_text`/`clear_text` with `compose.message` and `tap_element` with `compose.send`.
+The complete protocol regression can be run against a booted emulator with:
+
+```bash
+ANDROID_SERIAL=emulator-5554 ./verify-compose-mcp.sh
 ```

--- a/example/Android/app/build.gradle.kts
+++ b/example/Android/app/build.gradle.kts
@@ -1,6 +1,7 @@
 plugins {
     id("com.android.application")
     id("org.jetbrains.kotlin.android")
+    id("org.jetbrains.kotlin.plugin.compose")
 }
 
 android {
@@ -16,6 +17,7 @@ android {
     buildFeatures {
         viewBinding = true
         buildConfig = true
+        compose = true
     }
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
@@ -37,4 +39,9 @@ dependencies {
     implementation("androidx.constraintlayout:constraintlayout:2.1.4")
     implementation("androidx.swiperefreshlayout:swiperefreshlayout:1.1.0")
     implementation("androidx.webkit:webkit:1.10.0")
+    implementation("androidx.activity:activity-compose:1.8.2")
+    implementation("androidx.compose.ui:ui:1.6.1")
+    implementation("androidx.compose.ui:ui-tooling-preview:1.6.1")
+    implementation("androidx.compose.material3:material3:1.2.0")
+    debugImplementation("androidx.compose.ui:ui-tooling:1.6.1")
 }

--- a/example/Android/app/src/main/AndroidManifest.xml
+++ b/example/Android/app/src/main/AndroidManifest.xml
@@ -26,5 +26,9 @@
         <activity
             android:name=".screens.LoginActivity"
             android:theme="@style/Theme.AppRevealExample" />
+        <activity
+            android:name=".screens.ComposeActivity"
+            android:exported="true"
+            android:theme="@style/Theme.AppRevealExample" />
     </application>
 </manifest>

--- a/example/Android/app/src/main/kotlin/com/appreveal/example/screens/ComposeActivity.kt
+++ b/example/Android/app/src/main/kotlin/com/appreveal/example/screens/ComposeActivity.kt
@@ -1,0 +1,95 @@
+package com.appreveal.example.screens
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Button
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableIntStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.testTag
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.appreveal.screen.ScreenIdentifiable
+
+class ComposeActivity : ComponentActivity(), ScreenIdentifiable {
+    override val screenKey: String = "compose.test"
+    override val screenTitle: String = "Compose semantics"
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            MaterialTheme {
+                ComposeSemanticsScreen()
+            }
+        }
+    }
+}
+
+@Composable
+private fun ComposeSemanticsScreen() {
+    var message by remember { mutableStateOf("") }
+    var sentMessage by remember { mutableStateOf("") }
+    var sendCount by remember { mutableIntStateOf(0) }
+    var duplicateResult by remember { mutableStateOf("none") }
+
+    Column(
+        modifier =
+            Modifier
+                .fillMaxSize()
+                .padding(24.dp),
+        verticalArrangement = Arrangement.spacedBy(16.dp),
+    ) {
+        Text(
+            text = "Compose semantics test",
+            style = MaterialTheme.typography.headlineSmall,
+        )
+        OutlinedTextField(
+            value = message,
+            onValueChange = { message = it },
+            label = { Text("Message") },
+            modifier =
+                Modifier
+                    .fillMaxWidth()
+                    .testTag("compose.message"),
+        )
+        Button(
+            onClick = {
+                sentMessage = message
+                sendCount += 1
+            },
+            modifier = Modifier.testTag("compose.send"),
+        ) {
+            Text("Send a message")
+        }
+        Text("Sent: $sentMessage")
+        Text("Send count: $sendCount")
+        Button(onClick = { duplicateResult = "first" }) {
+            Text("Duplicate action")
+        }
+        Button(onClick = { duplicateResult = "second" }) {
+            Text("Duplicate action")
+        }
+        Text("Duplicate result: $duplicateResult")
+    }
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun ComposeSemanticsScreenPreview() {
+    MaterialTheme {
+        ComposeSemanticsScreen()
+    }
+}

--- a/example/Android/build.gradle.kts
+++ b/example/Android/build.gradle.kts
@@ -1,4 +1,5 @@
 plugins {
-    id("com.android.application") version "8.2.2" apply false
-    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+    id("com.android.application") version "8.7.3" apply false
+    id("org.jetbrains.kotlin.android") version "2.1.0" apply false
+    id("org.jetbrains.kotlin.plugin.compose") version "2.1.0" apply false
 }

--- a/example/Android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/Android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/example/Android/verify-compose-mcp.sh
+++ b/example/Android/verify-compose-mcp.sh
@@ -1,0 +1,82 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+if [[ -z "${JAVA_HOME:-}" && -x "/Applications/Android Studio.app/Contents/jbr/Contents/Home/bin/java" ]]; then
+    export JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home"
+fi
+ADB="${ANDROID_HOME:?Set ANDROID_HOME to the Android SDK}/platform-tools/adb"
+SERIAL="${ANDROID_SERIAL:-emulator-5554}"
+PACKAGE="com.appreveal.example"
+ACTIVITY="$PACKAGE/.screens.ComposeActivity"
+APK="$SCRIPT_DIR/app/build/outputs/apk/debug/app-debug.apk"
+
+"$SCRIPT_DIR/gradlew" -p "$SCRIPT_DIR" :app:assembleDebug
+"$ADB" -s "$SERIAL" install -r "$APK" >/dev/null
+"$ADB" -s "$SERIAL" logcat -c >/dev/null 2>&1 || true
+"$ADB" -s "$SERIAL" shell am force-stop "$PACKAGE"
+"$ADB" -s "$SERIAL" shell am start -W -n "$ACTIVITY" >/dev/null
+
+session_url=""
+for _ in {1..30}; do
+    session_url="$(
+        "$ADB" -s "$SERIAL" logcat -d -s AppReveal:I '*:S' |
+            sed -n 's/.*Session URL: //p' |
+            tail -1 |
+            tr -d '\r'
+    )"
+    if [[ -n "$session_url" ]]; then
+        break
+    fi
+    sleep 1
+done
+
+[[ -n "$session_url" ]] || { printf 'AppReveal session URL was not logged\n' >&2; exit 1; }
+
+port="$(printf '%s' "$session_url" | sed -E 's#http://127\.0\.0\.1:([0-9]+)/.*#\1#')"
+token="$(printf '%s' "$session_url" | sed -E 's#.*appreveal_session_token=([^[:space:]]+).*#\1#')"
+base_url="http://127.0.0.1:$port/"
+"$ADB" -s "$SERIAL" forward "tcp:$port" "tcp:$port" >/dev/null
+
+call_tool() {
+    local name="$1"
+    local arguments="$2"
+    curl -fsS "$base_url" \
+        -H "Authorization: Bearer $token" \
+        -H 'Content-Type: application/json' \
+        -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"$name\",\"arguments\":$arguments}}" |
+        jq -e '.result.content[0].text | fromjson'
+}
+
+call_tool get_screen '{}' | jq -e '.screenKey == "compose.test" and .frameworkType == "compose"' >/dev/null
+call_tool get_elements '{}' |
+    jq -e 'any(.elements[]; .id == "compose.message" and .type == "textField" and (.actions | contains("type"))) and any(.elements[]; .id == "compose.send" and .tappable == "true")' >/dev/null
+call_tool get_view_tree '{}' |
+    jq -e 'any(.views[]; .framework == "compose" and .accessibilityId == "compose.message")' >/dev/null
+
+call_tool type_text '{"element_id":"compose.message","text":"hello compose"}' | jq -e '.success == true' >/dev/null
+call_tool get_elements '{}' |
+    jq -e 'any(.elements[]; .id == "compose.message" and .value == "hello compose")' >/dev/null
+
+call_tool tap_text '{"text":"Send a message","match_mode":"exact"}' | jq -e '.success == true' >/dev/null
+call_tool get_elements '{}' |
+    jq -e 'any(.elements[]; .label == "Sent: hello compose") and any(.elements[]; .label == "Send count: 1")' >/dev/null
+
+call_tool tap_element '{"element_id":"compose.message"}' | jq -e '.success == true' >/dev/null
+call_tool type_text '{"text":" focused"}' | jq -e '.success == true' >/dev/null
+call_tool get_elements '{}' |
+    jq -e 'any(.elements[]; .id == "compose.message" and .value == "hello compose focused")' >/dev/null
+
+call_tool tap_element '{"element_id":"compose.send"}' | jq -e '.success == true' >/dev/null
+call_tool tap_element '{"element_id":"duplicate_action_1"}' | jq -e '.success == true' >/dev/null
+call_tool get_elements '{}' |
+    jq -e 'any(.elements[]; .label == "Send count: 2") and any(.elements[]; .label == "Duplicate result: second")' >/dev/null
+
+call_tool clear_text '{"element_id":"compose.message"}' | jq -e '.success == true' >/dev/null
+call_tool get_elements '{}' |
+    jq -e 'any(.elements[]; .id == "compose.message" and .value == "")' >/dev/null
+
+printf 'Compose MCP verification passed on %s (API %s)\n' \
+    "$SERIAL" \
+    "$("$ADB" -s "$SERIAL" shell getprop ro.build.version.sdk | tr -d '\r')"


### PR DESCRIPTION
## Summary

- traverse Jetpack Compose merged semantics tree in-process without adding a Compose dependency to the SDK
- expose stable Modifier.testTag IDs and Compose nodes through get_elements and get_view_tree
- route tap_element, tap_text, type_text, and clear_text through Compose semantics actions, including focused input and duplicate IDs
- add a dedicated Compose example fixture, repeatable MCP regression script, documentation, and Android build coverage

## Validation

- Android library check, ktlint, and lint: passed
- Android example assemble/lint: passed
- MCP regression on Android Emulator API 35: passed
- MCP regression on Android Emulator API 26: passed
- iOS example build and launch on iPhone 17 Pro Simulator (iOS 26.5): passed
- iOS Swift package tests: 8 passed
- git diff --check and shell syntax validation: passed

Fixes #47