### PR TITLE
Return screenshots as MCP image content blocks

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,12 +7,13 @@ on:
 
 jobs:
   swift:
-    name: SwiftLint (iOS/macOS)
+    name: Build, test, and lint (iOS/macOS)
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
       - run: brew install swiftlint
       - run: cd iOS && swiftlint lint --strict
+      - run: cd iOS && swift test
 
   android:
     name: Build and lint (Android)
@@ -24,18 +25,36 @@ jobs:
           distribution: temurin
           java-version: 17
       - uses: android-actions/setup-android@v3
-      - run: cd Android && chmod +x gradlew && ./gradlew ktlintCheck :appreveal:assembleDebug :appreveal:lintDebug
+      - run: cd Android && chmod +x gradlew && ./gradlew ktlintCheck :appreveal:testDebugUnitTest :appreveal:assembleDebug :appreveal:lintDebug
       - run: cd example/Android && chmod +x gradlew && ./gradlew :app:assembleDebug
 
   flutter:
-    name: dart analyze (Flutter)
+    name: Analyze and test (Flutter)
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: subosito/flutter-action@v2
         with:
           channel: stable
-      - run: cd Flutter/appreveal && flutter pub get && dart analyze --fatal-warnings
+      - run: cd Flutter/appreveal && flutter pub get && flutter analyze --fatal-warnings
+      - run: cd Flutter/appreveal && flutter test
+
+  windows:
+    name: Build (.NET Windows)
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-dotnet@v4
+        with:
+          dotnet-version: 8.0.x
+      - run: dotnet build Windows/AppReveal.Windows/AppReveal.Windows.csproj
+
+  tauri:
+    name: Test (Tauri/Rust)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - run: cargo test --manifest-path Windows/appreveal-tauri/Cargo.toml -- --test-threads=1
 
   reactnative:
     name: ESLint (React Native)

--- a/.gitignore
+++ b/.gitignore
@@ -41,6 +41,11 @@ CLI/node_modules/
 CLI/dist/
 ReactNative/appreveal/node_modules/
 
+# Flutter / Dart
+**/.dart_tool/
+**/.flutter-plugins-dependencies
+Flutter/appreveal/pubspec.lock
+
 # Archives and distribution
 *.ipa
 *.xcarchive

--- a/Android/appreveal/build.gradle.kts
+++ b/Android/appreveal/build.gradle.kts
@@ -33,4 +33,5 @@ dependencies {
     implementation("androidx.recyclerview:recyclerview:1.3.2")
     implementation("com.google.android.material:material:1.11.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+    testImplementation("junit:junit:4.13.2")
 }

--- a/Android/appreveal/src/main/kotlin/com/appreveal/mcpserver/MCPRouter.kt
+++ b/Android/appreveal/src/main/kotlin/com/appreveal/mcpserver/MCPRouter.kt
@@ -86,21 +86,7 @@ internal object MCPRouter {
                 try {
                     val arguments = params.getAsJsonObject("arguments")
                     val handlerResult = tool.handler(arguments)
-                    val resultJson = MCPGson.gson.toJson(handlerResult)
-
-                    val content =
-                        JsonArray().apply {
-                            add(
-                                JsonObject().apply {
-                                    addProperty("type", "text")
-                                    addProperty("text", resultJson)
-                                },
-                            )
-                        }
-                    val result =
-                        JsonObject().apply {
-                            add("content", content)
-                        }
+                    val result = toolCallResult(toolName, handlerResult)
                     MCPResponse.success(request.id, result)
                 } catch (e: Exception) {
                     MCPResponse.error(request.id, MCPError.internalError(e.message ?: "Unknown error"))
@@ -112,4 +98,64 @@ internal object MCPRouter {
             }
         }
     }
+
+    private fun toolCallResult(
+        toolName: String,
+        handlerResult: JsonElement,
+    ): JsonObject {
+        if (toolName != "screenshot" || !handlerResult.isJsonObject) {
+            return textToolResult(handlerResult)
+        }
+
+        val screenshot = handlerResult.asJsonObject
+        val imageData = screenshot.get("image")?.asStringOrNull()
+        if (imageData.isNullOrBlank()) {
+            return textToolResult(handlerResult, isError = true)
+        }
+
+        val format = screenshot.get("format")?.asStringOrNull()?.lowercase() ?: "png"
+        val mimeType = if (format == "jpeg" || format == "jpg") "image/jpeg" else "image/png"
+        val metadata = screenshot.deepCopy().apply { remove("image") }
+
+        return JsonObject().apply {
+            add(
+                "content",
+                JsonArray().apply {
+                    add(
+                        JsonObject().apply {
+                            addProperty("type", "image")
+                            addProperty("data", imageData)
+                            addProperty("mimeType", mimeType)
+                        },
+                    )
+                    add(
+                        JsonObject().apply {
+                            addProperty("type", "text")
+                            addProperty("text", MCPGson.gson.toJson(metadata))
+                        },
+                    )
+                },
+            )
+            add("structuredContent", metadata.deepCopy())
+        }
+    }
+
+    private fun textToolResult(
+        handlerResult: JsonElement,
+        isError: Boolean = false,
+    ): JsonObject =
+        JsonObject().apply {
+            add(
+                "content",
+                JsonArray().apply {
+                    add(
+                        JsonObject().apply {
+                            addProperty("type", "text")
+                            addProperty("text", MCPGson.gson.toJson(handlerResult))
+                        },
+                    )
+                },
+            )
+            if (isError) addProperty("isError", true)
+        }
 }

--- a/Android/appreveal/src/main/kotlin/com/appreveal/mcpserver/MCPTools.kt
+++ b/Android/appreveal/src/main/kotlin/com/appreveal/mcpserver/MCPTools.kt
@@ -354,7 +354,7 @@ internal fun registerBuiltInTools() {
     router.register(
         MCPToolDefinition(
             name = "screenshot",
-            description = "Capture a screenshot of the current screen. Returns base64-encoded image.",
+            description = "Capture a screenshot of the current screen. Returns an MCP image content block.",
             inputSchema =
                 jsonSchema(
                     "element_id" to jsonProp("string", "Optional element ID to crop to"),
@@ -955,6 +955,18 @@ internal fun registerBuiltInTools() {
                             JsonObject().apply {
                                 addProperty("index", index)
                                 addProperty("error", "Invalid action format")
+                            },
+                        )
+                        if (stopOnError) break
+                        continue
+                    }
+
+                    if (toolName == "screenshot") {
+                        results.add(
+                            JsonObject().apply {
+                                addProperty("index", index)
+                                addProperty("tool", toolName)
+                                addProperty("error", "screenshot must be called directly to return MCP image content")
                             },
                         )
                         if (stopOnError) break

--- a/Android/appreveal/src/test/kotlin/com/appreveal/mcpserver/MCPRouterTest.kt
+++ b/Android/appreveal/src/test/kotlin/com/appreveal/mcpserver/MCPRouterTest.kt
@@ -1,0 +1,130 @@
+package com.appreveal.mcpserver
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class MCPRouterTest {
+    @Before
+    fun setUp() {
+        MCPRouter.clearAll()
+    }
+
+    @After
+    fun tearDown() {
+        MCPRouter.clearAll()
+    }
+
+    @Test
+    fun `screenshot returns image content and metadata for png and jpeg`() {
+        listOf("png" to "image/png", "jpeg" to "image/jpeg").forEach { (format, mimeType) ->
+            MCPRouter.clearAll()
+            registerTool("screenshot") {
+                JsonObject().apply {
+                    addProperty("image", "base64-$format")
+                    addProperty("width", 100)
+                    addProperty("height", 200)
+                    addProperty("scale", 2.0)
+                    addProperty("format", format)
+                }
+            }
+
+            val result = callTool("screenshot")
+            val content = result.getAsJsonArray("content")
+            val image = content[0].asJsonObject
+            val metadata = result.getAsJsonObject("structuredContent")
+
+            assertEquals("image", image.get("type").asString)
+            assertEquals("base64-$format", image.get("data").asString)
+            assertEquals(mimeType, image.get("mimeType").asString)
+            assertFalse(metadata.has("image"))
+            assertEquals(100, metadata.get("width").asInt)
+            assertEquals(metadata, MCPGson.gson.fromJson(content[1].asJsonObject.get("text").asString, JsonObject::class.java))
+        }
+    }
+
+    @Test
+    fun `failed screenshot remains text and is marked as an error`() {
+        registerTool("screenshot") {
+            JsonObject().apply { addProperty("error", "capture failed") }
+        }
+
+        val result = callTool("screenshot")
+
+        assertTrue(result.get("isError").asBoolean)
+        assertEquals("text", result.getAsJsonArray("content")[0].asJsonObject.get("type").asString)
+        assertFalse(result.has("structuredContent"))
+    }
+
+    @Test
+    fun `ordinary tool result remains a single text block`() {
+        registerTool("get_state") {
+            JsonObject().apply { addProperty("count", 2) }
+        }
+
+        val result = callTool("get_state")
+
+        assertEquals(1, result.getAsJsonArray("content").size())
+        assertEquals("text", result.getAsJsonArray("content")[0].asJsonObject.get("type").asString)
+        assertFalse(result.has("structuredContent"))
+        assertFalse(result.has("isError"))
+    }
+
+    @Test
+    fun `batch rejects screenshot with direct call instruction`() {
+        registerBuiltInTools()
+        val arguments =
+            JsonObject().apply {
+                add(
+                    "actions",
+                    JsonArray().apply {
+                        add(JsonObject().apply { addProperty("tool", "screenshot") })
+                    },
+                )
+            }
+
+        val result = callTool("batch", arguments)
+        val batchResult =
+            MCPGson.gson.fromJson(
+                result.getAsJsonArray("content")[0].asJsonObject.get("text").asString,
+                JsonObject::class.java,
+            )
+
+        assertEquals(
+            "screenshot must be called directly to return MCP image content",
+            batchResult.getAsJsonArray("results")[0].asJsonObject.get("error").asString,
+        )
+    }
+
+    private fun registerTool(
+        name: String,
+        handler: () -> JsonObject,
+    ) {
+        MCPRouter.register(
+            MCPToolDefinition(
+                name = name,
+                description = name,
+                inputSchema = JsonObject(),
+                handler = { handler() },
+            ),
+        )
+    }
+
+    private fun callTool(
+        name: String,
+        arguments: JsonObject = JsonObject(),
+    ): JsonObject {
+        val params =
+            JsonObject().apply {
+                addProperty("name", name)
+                add("arguments", arguments)
+            }
+        val response = MCPRouter.handle(MCPRequest("2.0", 1, "tools/call", params))
+        return response.result!!.asJsonObject
+    }
+}

--- a/Flutter/appreveal/lib/src/mcp/mcp_router.dart
+++ b/Flutter/appreveal/lib/src/mcp/mcp_router.dart
@@ -4,16 +4,20 @@ import 'dart:convert';
 
 typedef MCPToolHandler = Future<dynamic> Function(Map<String, dynamic>? params);
 
+enum MCPToolOutputKind { jsonText, image }
+
 class MCPToolDefinition {
   final String name;
   final String description;
   final Map<String, dynamic> inputSchema;
+  final MCPToolOutputKind outputKind;
   final MCPToolHandler handler;
 
   const MCPToolDefinition({
     required this.name,
     required this.description,
     required this.inputSchema,
+    this.outputKind = MCPToolOutputKind.jsonText,
     required this.handler,
   });
 }
@@ -43,11 +47,13 @@ class MCPRouter {
         });
 
       case 'tools/list':
-        final toolList = _tools.values.map((t) => {
-          'name': t.name,
-          'description': t.description,
-          'inputSchema': t.inputSchema,
-        }).toList();
+        final toolList = _tools.values
+            .map((t) => {
+                  'name': t.name,
+                  'description': t.description,
+                  'inputSchema': t.inputSchema,
+                })
+            .toList();
         return _response(id, {'tools': toolList});
 
       case 'tools/call':
@@ -63,10 +69,7 @@ class MCPRouter {
         try {
           final args = params?['arguments'] as Map<String, dynamic>?;
           final result = await definition.handler(args);
-          final resultJson = jsonEncode(result);
-          return _response(id, {
-            'content': [{'type': 'text', 'text': resultJson}],
-          });
+          return _response(id, _toolCallResult(result, definition.outputKind));
         } catch (e) {
           return _error(id, -32603, e.toString());
         }
@@ -77,14 +80,71 @@ class MCPRouter {
   }
 
   static Map<String, dynamic> _response(dynamic id, dynamic result) => {
-    'jsonrpc': '2.0',
-    'id': id,
-    'result': result,
-  };
+        'jsonrpc': '2.0',
+        'id': id,
+        'result': result,
+      };
 
   static Map<String, dynamic> _error(dynamic id, int code, String message) => {
-    'jsonrpc': '2.0',
-    'id': id,
-    'error': {'code': code, 'message': message},
-  };
+        'jsonrpc': '2.0',
+        'id': id,
+        'error': {'code': code, 'message': message},
+      };
+
+  static Map<String, dynamic> _toolCallResult(
+    dynamic result,
+    MCPToolOutputKind outputKind,
+  ) {
+    return switch (outputKind) {
+      MCPToolOutputKind.jsonText => _textToolCallResult(result),
+      MCPToolOutputKind.image => _imageToolCallResult(result),
+    };
+  }
+
+  static Map<String, dynamic> _textToolCallResult(
+    dynamic result, {
+    bool isError = false,
+  }) {
+    final response = <String, dynamic>{
+      'content': [
+        {'type': 'text', 'text': jsonEncode(result)},
+      ],
+    };
+    if (isError) response['isError'] = true;
+    return response;
+  }
+
+  static Map<String, dynamic> _imageToolCallResult(dynamic result) {
+    if (result is! Map<String, dynamic>) {
+      return _textToolCallResult(
+        {'error': 'Screenshot returned an invalid result'},
+        isError: true,
+      );
+    }
+
+    if (result.containsKey('error')) {
+      return _textToolCallResult(result, isError: true);
+    }
+
+    final imageData = result['image'];
+    final format = result['format'];
+    if (imageData is! String ||
+        imageData.isEmpty ||
+        (format != 'png' && format != 'jpeg')) {
+      return _textToolCallResult(
+        {'error': 'Screenshot returned invalid image data or format'},
+        isError: true,
+      );
+    }
+
+    final metadata = Map<String, dynamic>.from(result)..remove('image');
+    final mimeType = format == 'jpeg' ? 'image/jpeg' : 'image/png';
+    return {
+      'content': [
+        {'type': 'image', 'data': imageData, 'mimeType': mimeType},
+        {'type': 'text', 'text': jsonEncode(metadata)},
+      ],
+      'structuredContent': metadata,
+    };
+  }
 }

--- a/Flutter/appreveal/lib/src/mcp/mcp_tools.dart
+++ b/Flutter/appreveal/lib/src/mcp/mcp_tools.dart
@@ -80,7 +80,7 @@ void registerBuiltInTools() {
     MCPToolDefinition(
       name: 'screenshot',
       description:
-          'Capture a screenshot of the current screen. Returns base64-encoded image.',
+          'Capture a screenshot of the current screen. Returns a standard MCP image content block with dimensions and format metadata.',
       inputSchema: {
         'type': 'object',
         'properties': {
@@ -95,8 +95,9 @@ void registerBuiltInTools() {
           },
         },
       },
+      outputKind: MCPToolOutputKind.image,
       handler: (params) async {
-        final format = params?['format'] as String? ?? 'png';
+        final format = params?['format'] == 'jpeg' ? 'jpeg' : 'png';
         final elementId = params?['element_id'] as String?;
         if (elementId != null) {
           return ScreenshotCapture.shared.captureElement(
@@ -555,8 +556,8 @@ void registerBuiltInTools() {
             'platform': Platform.isIOS
                 ? 'iOS'
                 : Platform.isAndroid
-                ? 'Android'
-                : Platform.operatingSystem,
+                    ? 'Android'
+                    : Platform.operatingSystem,
             'frameworkType': 'flutter',
             'debugMode': kDebugMode,
           };
@@ -605,8 +606,8 @@ void registerBuiltInTools() {
             'platform': Platform.isIOS
                 ? 'iOS'
                 : Platform.isAndroid
-                ? 'Android'
-                : Platform.operatingSystem,
+                    ? 'Android'
+                    : Platform.operatingSystem,
             'frameworkType': 'flutter',
             'debugMode': kDebugMode,
 
@@ -644,12 +645,12 @@ void registerBuiltInTools() {
             // Environment (non-secret keys only)
             'environment': Platform.environment.entries
                 .where(
-                  (e) =>
-                      !e.key.toLowerCase().contains('secret') &&
-                      !e.key.toLowerCase().contains('token') &&
-                      !e.key.toLowerCase().contains('password') &&
-                      !e.key.toLowerCase().contains('key'),
-                )
+              (e) =>
+                  !e.key.toLowerCase().contains('secret') &&
+                  !e.key.toLowerCase().contains('token') &&
+                  !e.key.toLowerCase().contains('password') &&
+                  !e.key.toLowerCase().contains('key'),
+            )
                 .fold(<String, String>{}, (map, e) => map..[e.key] = e.value),
           };
         } catch (e) {
@@ -724,6 +725,17 @@ void registerBuiltInTools() {
               'index': i,
               'tool': toolName,
               'error': 'Tool not found',
+            });
+            if (stopOnError) break;
+            continue;
+          }
+
+          if (definition.outputKind == MCPToolOutputKind.image) {
+            results.add({
+              'index': i,
+              'tool': toolName,
+              'error':
+                  'Image tools cannot run inside batch. Call screenshot directly to receive an MCP image block.',
             });
             if (stopOnError) break;
             continue;

--- a/Flutter/appreveal/lib/src/screenshot/screenshot_capture.dart
+++ b/Flutter/appreveal/lib/src/screenshot/screenshot_capture.dart
@@ -2,8 +2,10 @@
 
 import 'dart:convert';
 import 'dart:ui' as ui;
+import 'package:flutter/foundation.dart';
 import 'package:flutter/rendering.dart';
 import 'package:flutter/widgets.dart';
+import 'package:image/image.dart' as img;
 
 import '../elements/element_inventory.dart';
 
@@ -13,6 +15,34 @@ class ScreenshotCapture {
 
   /// Optional explicit repaint boundary key, set via [AppReveal.wrap].
   static final screenshotKey = GlobalKey();
+
+  @visibleForTesting
+  static Uint8List encodeImageBytes({
+    required ByteData byteData,
+    required int width,
+    required int height,
+    required String format,
+  }) {
+    if (format != 'jpeg') {
+      return byteData.buffer.asUint8List(
+        byteData.offsetInBytes,
+        byteData.lengthInBytes,
+      );
+    }
+
+    return img.encodeJpg(
+      img.Image.fromBytes(
+        width: width,
+        height: height,
+        bytes: byteData.buffer,
+        bytesOffset: byteData.offsetInBytes,
+        numChannels: 4,
+        rowStride: width * 4,
+        order: img.ChannelOrder.rgba,
+      ),
+      quality: 85,
+    );
+  }
 
   Future<Map<String, dynamic>> captureScreen({String format = 'png'}) async {
     // Try the explicit key first
@@ -83,22 +113,34 @@ class ScreenshotCapture {
     RenderRepaintBoundary boundary, {
     required String format,
   }) async {
+    final normalizedFormat = format == 'jpeg' ? 'jpeg' : 'png';
     try {
       final image = await boundary.toImage(pixelRatio: 2.0);
-      final byteData = await image.toByteData(
-        format: format == 'jpeg'
-            ? ui.ImageByteFormat.rawRgba
-            : ui.ImageByteFormat.png,
-      );
-      if (byteData == null) return {'error': 'Failed to encode image'};
-      final base64Image = base64Encode(byteData.buffer.asUint8List());
-      return {
-        'image': base64Image,
-        'width': image.width,
-        'height': image.height,
-        'scale': 2.0,
-        'format': format,
-      };
+      try {
+        final byteData = await image.toByteData(
+          format: normalizedFormat == 'jpeg'
+              ? ui.ImageByteFormat.rawRgba
+              : ui.ImageByteFormat.png,
+        );
+        if (byteData == null) return {'error': 'Failed to encode image'};
+
+        final encodedBytes = encodeImageBytes(
+          byteData: byteData,
+          width: image.width,
+          height: image.height,
+          format: normalizedFormat,
+        );
+
+        return {
+          'image': base64Encode(encodedBytes),
+          'width': image.width,
+          'height': image.height,
+          'scale': 2.0,
+          'format': normalizedFormat,
+        };
+      } finally {
+        image.dispose();
+      }
     } catch (e) {
       return {'error': e.toString()};
     }

--- a/Flutter/appreveal/pubspec.yaml
+++ b/Flutter/appreveal/pubspec.yaml
@@ -12,6 +12,7 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
+  image: ^4.5.4
   package_info_plus: ^8.0.0
   url_launcher: ^6.3.0
   webview_flutter: ^4.10.0

--- a/Flutter/appreveal/test/mcp_router_test.dart
+++ b/Flutter/appreveal/test/mcp_router_test.dart
@@ -1,0 +1,128 @@
+import 'dart:convert';
+
+import 'package:appreveal/src/mcp/mcp_router.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('image tool returns MCP image block and metadata', () async {
+    const toolName = 'test_image_result';
+    const imageData = 'iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB';
+    MCPRouter.shared.register(
+      MCPToolDefinition(
+        name: toolName,
+        description: 'Test image',
+        inputSchema: const {'type': 'object', 'properties': {}},
+        outputKind: MCPToolOutputKind.image,
+        handler: (_) async => {
+          'image': imageData,
+          'width': 120,
+          'height': 240,
+          'scale': 2.0,
+          'format': 'png',
+        },
+      ),
+    );
+
+    final result = await callTool(toolName);
+    final content = result['content'] as List<dynamic>;
+    final image = content[0] as Map<String, dynamic>;
+    final metadataBlock = content[1] as Map<String, dynamic>;
+
+    expect(content, hasLength(2));
+    expect(image['type'], 'image');
+    expect(image['data'], imageData);
+    expect(image['mimeType'], 'image/png');
+    expect(metadataBlock['type'], 'text');
+
+    final metadataText = metadataBlock['text'] as String;
+    expect(metadataText, isNot(contains(imageData)));
+    final metadataFromText = jsonDecode(metadataText) as Map<String, dynamic>;
+    expect(metadataFromText['width'], 120);
+    expect(metadataFromText['format'], 'png');
+    expect(metadataFromText, isNot(contains('image')));
+
+    final structuredContent =
+        result['structuredContent'] as Map<String, dynamic>;
+    expect(structuredContent['height'], 240);
+    expect(structuredContent['scale'], 2.0);
+    expect(structuredContent, isNot(contains('image')));
+    expect(result, isNot(contains('isError')));
+  });
+
+  test('image tool maps JPEG MIME type', () async {
+    const toolName = 'test_jpeg_result';
+    MCPRouter.shared.register(
+      MCPToolDefinition(
+        name: toolName,
+        description: 'Test JPEG',
+        inputSchema: const {'type': 'object', 'properties': {}},
+        outputKind: MCPToolOutputKind.image,
+        handler: (_) async => {
+          'image': '/9j/4AAQSkZJRgABAQAAAQABAAD',
+          'width': 20,
+          'height': 10,
+          'scale': 1.0,
+          'format': 'jpeg',
+        },
+      ),
+    );
+
+    final result = await callTool(toolName);
+    final content = result['content'] as List<dynamic>;
+    final image = content.first as Map<String, dynamic>;
+
+    expect(image['mimeType'], 'image/jpeg');
+  });
+
+  test('image tool failure returns a text error', () async {
+    const toolName = 'test_image_failure';
+    MCPRouter.shared.register(
+      MCPToolDefinition(
+        name: toolName,
+        description: 'Test image failure',
+        inputSchema: const {'type': 'object', 'properties': {}},
+        outputKind: MCPToolOutputKind.image,
+        handler: (_) async => {'error': 'Capture failed'},
+      ),
+    );
+
+    final result = await callTool(toolName);
+    final content = result['content'] as List<dynamic>;
+    final error = content.single as Map<String, dynamic>;
+
+    expect(error['type'], 'text');
+    expect(error['text'], contains('Capture failed'));
+    expect(result['isError'], isTrue);
+    expect(result, isNot(contains('structuredContent')));
+  });
+
+  test('JSON tool keeps the text result shape', () async {
+    const toolName = 'test_json_result';
+    MCPRouter.shared.register(
+      MCPToolDefinition(
+        name: toolName,
+        description: 'Test JSON',
+        inputSchema: const {'type': 'object', 'properties': {}},
+        handler: (_) async => {'value': 'ok'},
+      ),
+    );
+
+    final result = await callTool(toolName);
+    final content = result['content'] as List<dynamic>;
+    final text = content.single as Map<String, dynamic>;
+
+    expect(text['type'], 'text');
+    expect(jsonDecode(text['text'] as String), {'value': 'ok'});
+    expect(result, isNot(contains('structuredContent')));
+  });
+}
+
+Future<Map<String, dynamic>> callTool(String name) async {
+  final response = await MCPRouter.shared.handle({
+    'jsonrpc': '2.0',
+    'id': 1,
+    'method': 'tools/call',
+    'params': {'name': name, 'arguments': <String, dynamic>{}},
+  });
+  return response['result'] as Map<String, dynamic>;
+}

--- a/Flutter/appreveal/test/screenshot_capture_test.dart
+++ b/Flutter/appreveal/test/screenshot_capture_test.dart
@@ -1,0 +1,38 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:appreveal/src/screenshot/screenshot_capture.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('JPEG encoder returns valid JPEG bytes', () {
+    final rgba = Uint8List.fromList([
+      255,
+      0,
+      0,
+      255,
+      0,
+      255,
+      0,
+      255,
+      0,
+      0,
+      255,
+      255,
+      255,
+      255,
+      255,
+      255,
+    ]);
+    final bytes = ScreenshotCapture.encodeImageBytes(
+      byteData: ByteData.sublistView(rgba),
+      width: 2,
+      height: 2,
+      format: 'jpeg',
+    );
+    final decoded = base64Decode(base64Encode(bytes));
+
+    expect(decoded.take(2), [0xFF, 0xD8]);
+    expect(decoded.skip(decoded.length - 2), [0xFF, 0xD9]);
+  });
+}

--- a/README.md
+++ b/README.md
@@ -151,7 +151,7 @@ See [Windows guide](docs/windows.md) for the native C# and Tauri/Rust setup note
 | `clear_text` | Clear a text field |
 | `scroll` | Scroll a container (up/down/left/right) |
 | `scroll_to_element` | Scroll until an element is visible |
-| `screenshot` | Capture screen or element as base64 PNG/JPEG |
+| `screenshot` | Capture a screen or element as an MCP image content block |
 | `select_tab` | Switch tab bar tabs by index |
 | `navigate_back` | Pop the navigation stack |
 | `dismiss_modal` | Dismiss the topmost modal |

--- a/ReactNative/README.md
+++ b/ReactNative/README.md
@@ -190,7 +190,7 @@ These tools are available on React Native iOS and Android.
 | `clear_text` | Clear a text field |
 | `scroll` | Scroll a container (up/down/left/right) |
 | `scroll_to_element` | Scroll until an element is visible |
-| `screenshot` | Capture screen or element as base64 PNG/JPEG |
+| `screenshot` | Capture a screen or element as an MCP image content block |
 | `select_tab` | Switch tab bar tabs by index |
 | `navigate_back` | Pop the navigation stack |
 | `dismiss_modal` | Dismiss the topmost modal |

--- a/ReactNative/appreveal/android/build.gradle
+++ b/ReactNative/appreveal/android/build.gradle
@@ -62,4 +62,6 @@ dependencies {
     implementation 'androidx.fragment:fragment-ktx:1.6.2'
     implementation 'androidx.recyclerview:recyclerview:1.3.2'
     implementation 'com.google.android.material:material:1.11.0'
+
+    testImplementation 'junit:junit:4.13.2'
 }

--- a/ReactNative/appreveal/android/src/main/kotlin/com/appreveal/mcpserver/MCPRouter.kt
+++ b/ReactNative/appreveal/android/src/main/kotlin/com/appreveal/mcpserver/MCPRouter.kt
@@ -76,17 +76,7 @@ internal object MCPRouter {
                 try {
                     val arguments = params.getAsJsonObject("arguments")
                     val handlerResult = tool.handler(arguments)
-                    val resultJson = MCPGson.gson.toJson(handlerResult)
-
-                    val content = JsonArray().apply {
-                        add(JsonObject().apply {
-                            addProperty("type", "text")
-                            addProperty("text", resultJson)
-                        })
-                    }
-                    val result = JsonObject().apply {
-                        add("content", content)
-                    }
+                    val result = toolCallResult(toolName, handlerResult)
                     MCPResponse.success(request.id, result)
                 } catch (e: Exception) {
                     MCPResponse.error(request.id, MCPError.internalError(e.message ?: "Unknown error"))
@@ -94,6 +84,49 @@ internal object MCPRouter {
             }
 
             else -> MCPResponse.error(request.id, MCPError.methodNotFound(request.method))
+        }
+    }
+
+    private fun toolCallResult(toolName: String, handlerResult: JsonElement): JsonObject {
+        if (toolName != "screenshot" || !handlerResult.isJsonObject) {
+            return textToolResult(handlerResult)
+        }
+
+        val screenshot = handlerResult.asJsonObject
+        val imageData = screenshot.get("image")?.asStringOrNull()
+        if (imageData.isNullOrBlank()) {
+            return textToolResult(handlerResult, isError = true)
+        }
+
+        val format = screenshot.get("format")?.asStringOrNull()?.lowercase() ?: "png"
+        val mimeType = if (format == "jpeg" || format == "jpg") "image/jpeg" else "image/png"
+        val metadata = screenshot.deepCopy().apply { remove("image") }
+
+        return JsonObject().apply {
+            add("content", JsonArray().apply {
+                add(JsonObject().apply {
+                    addProperty("type", "image")
+                    addProperty("data", imageData)
+                    addProperty("mimeType", mimeType)
+                })
+                add(JsonObject().apply {
+                    addProperty("type", "text")
+                    addProperty("text", MCPGson.gson.toJson(metadata))
+                })
+            })
+            add("structuredContent", metadata.deepCopy())
+        }
+    }
+
+    private fun textToolResult(handlerResult: JsonElement, isError: Boolean = false): JsonObject {
+        return JsonObject().apply {
+            add("content", JsonArray().apply {
+                add(JsonObject().apply {
+                    addProperty("type", "text")
+                    addProperty("text", MCPGson.gson.toJson(handlerResult))
+                })
+            })
+            if (isError) addProperty("isError", true)
         }
     }
 }

--- a/ReactNative/appreveal/android/src/main/kotlin/com/appreveal/mcpserver/MCPTools.kt
+++ b/ReactNative/appreveal/android/src/main/kotlin/com/appreveal/mcpserver/MCPTools.kt
@@ -303,7 +303,7 @@ internal fun registerBuiltInTools() {
 
     router.register(MCPToolDefinition(
         name = "screenshot",
-        description = "Capture a screenshot of the current screen. Returns base64-encoded image.",
+        description = "Capture a screenshot of the current screen. Returns an MCP image content block.",
         inputSchema = jsonSchema(
             "element_id" to jsonProp("string", "Optional element ID to crop to"),
             "format" to JsonObject().apply {
@@ -684,6 +684,16 @@ internal fun registerBuiltInTools() {
                     results.add(JsonObject().apply {
                         addProperty("index", index)
                         addProperty("error", "Invalid action format")
+                    })
+                    if (stopOnError) break
+                    continue
+                }
+
+                if (toolName == "screenshot") {
+                    results.add(JsonObject().apply {
+                        addProperty("index", index)
+                        addProperty("tool", toolName)
+                        addProperty("error", "screenshot must be called directly to return MCP image content")
                     })
                     if (stopOnError) break
                     continue

--- a/ReactNative/appreveal/android/src/test/kotlin/com/appreveal/mcpserver/MCPRouterTest.kt
+++ b/ReactNative/appreveal/android/src/test/kotlin/com/appreveal/mcpserver/MCPRouterTest.kt
@@ -1,0 +1,117 @@
+package com.appreveal.mcpserver
+
+import com.google.gson.JsonArray
+import com.google.gson.JsonObject
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class MCPRouterTest {
+    @Before
+    fun setUp() {
+        MCPRouter.clearAll()
+    }
+
+    @After
+    fun tearDown() {
+        MCPRouter.clearAll()
+    }
+
+    @Test
+    fun screenshotReturnsImageContentAndMetadata() {
+        listOf("png" to "image/png", "jpeg" to "image/jpeg").forEach { (format, mimeType) ->
+            MCPRouter.clearAll()
+            registerTool("screenshot") {
+                JsonObject().apply {
+                    addProperty("image", "base64-$format")
+                    addProperty("width", 100)
+                    addProperty("height", 200)
+                    addProperty("scale", 2.0)
+                    addProperty("format", format)
+                }
+            }
+
+            val result = callTool("screenshot")
+            val content = result.getAsJsonArray("content")
+            val image = content[0].asJsonObject
+            val metadata = result.getAsJsonObject("structuredContent")
+
+            assertEquals("image", image.get("type").asString)
+            assertEquals("base64-$format", image.get("data").asString)
+            assertEquals(mimeType, image.get("mimeType").asString)
+            assertFalse(metadata.has("image"))
+            assertEquals(metadata, MCPGson.gson.fromJson(content[1].asJsonObject.get("text").asString, JsonObject::class.java))
+        }
+    }
+
+    @Test
+    fun failedScreenshotIsMarkedAsAnError() {
+        registerTool("screenshot") {
+            JsonObject().apply { addProperty("error", "capture failed") }
+        }
+
+        val result = callTool("screenshot")
+
+        assertTrue(result.get("isError").asBoolean)
+        assertEquals("text", result.getAsJsonArray("content")[0].asJsonObject.get("type").asString)
+        assertFalse(result.has("structuredContent"))
+    }
+
+    @Test
+    fun ordinaryResultRemainsTextOnly() {
+        registerTool("get_state") {
+            JsonObject().apply { addProperty("count", 2) }
+        }
+
+        val result = callTool("get_state")
+
+        assertEquals(1, result.getAsJsonArray("content").size())
+        assertEquals("text", result.getAsJsonArray("content")[0].asJsonObject.get("type").asString)
+        assertFalse(result.has("structuredContent"))
+        assertFalse(result.has("isError"))
+    }
+
+    @Test
+    fun batchRejectsScreenshotWithDirectCallInstruction() {
+        registerBuiltInTools()
+        val arguments = JsonObject().apply {
+            add("actions", JsonArray().apply {
+                add(JsonObject().apply { addProperty("tool", "screenshot") })
+            })
+        }
+
+        val result = callTool("batch", arguments)
+        val batchResult = MCPGson.gson.fromJson(
+            result.getAsJsonArray("content")[0].asJsonObject.get("text").asString,
+            JsonObject::class.java
+        )
+
+        assertEquals(
+            "screenshot must be called directly to return MCP image content",
+            batchResult.getAsJsonArray("results")[0].asJsonObject.get("error").asString
+        )
+    }
+
+    private fun registerTool(name: String, handler: () -> JsonObject) {
+        MCPRouter.register(
+            MCPToolDefinition(
+                name = name,
+                description = name,
+                inputSchema = JsonObject(),
+                handler = { handler() }
+            )
+        )
+    }
+
+    private fun callTool(name: String, arguments: JsonObject = JsonObject()): JsonObject {
+        val params = JsonObject().apply {
+            addProperty("name", name)
+            add("arguments", arguments)
+        }
+        val response = MCPRouter.handle(MCPRequest("2.0", 1, "tools/call", params))
+        return response.result!!.asJsonObject
+    }
+}

--- a/ReactNative/appreveal/ios/MCPRouter.swift
+++ b/ReactNative/appreveal/ios/MCPRouter.swift
@@ -6,11 +6,31 @@ typealias MCPToolHandler = @MainActor (
     _ params: [String: AnyCodable]?
 ) async throws -> AnyCodable
 
+enum MCPToolOutputKind {
+    case jsonText
+    case image
+}
+
 struct MCPToolDefinition {
     let name: String
     let description: String
     let inputSchema: [String: AnyCodable]
+    let outputKind: MCPToolOutputKind
     let handler: MCPToolHandler
+
+    init(
+        name: String,
+        description: String,
+        inputSchema: [String: AnyCodable],
+        outputKind: MCPToolOutputKind = .jsonText,
+        handler: @escaping MCPToolHandler
+    ) {
+        self.name = name
+        self.description = description
+        self.inputSchema = inputSchema
+        self.outputKind = outputKind
+        self.handler = handler
+    }
 }
 
 @MainActor
@@ -67,13 +87,10 @@ final class MCPRouter {
             do {
                 let arguments = params["arguments"]?.dictionaryValue
                 let result = try await tool.handler(arguments)
-                let resultData = try JSONEncoder().encode(result)
-                let resultString = String(data: resultData, encoding: .utf8) ?? "{}"
-                return MCPResponse(id: request.id, result: AnyCodable([
-                    "content": [
-                        ["type": "text", "text": resultString]
-                    ]
-                ] as [String: Any]))
+                return MCPResponse(
+                    id: request.id,
+                    result: try makeToolCallResult(result, outputKind: tool.outputKind)
+                )
             } catch {
                 return MCPResponse(id: request.id, error: .internalError(error.localizedDescription))
             }
@@ -81,5 +98,80 @@ final class MCPRouter {
         default:
             return MCPResponse(id: request.id, error: .methodNotFound(request.method))
         }
+    }
+
+    private func makeToolCallResult(
+        _ result: AnyCodable,
+        outputKind: MCPToolOutputKind
+    ) throws -> AnyCodable {
+        switch outputKind {
+        case .jsonText:
+            return try makeTextToolCallResult(result)
+        case .image:
+            return try makeImageToolCallResult(result)
+        }
+    }
+
+    private func makeTextToolCallResult(
+        _ result: AnyCodable,
+        isError: Bool = false
+    ) throws -> AnyCodable {
+        var payload: [String: Any] = [
+            "content": [
+                ["type": "text", "text": try jsonString(for: result)]
+            ]
+        ]
+        if isError {
+            payload["isError"] = true
+        }
+        return AnyCodable(payload)
+    }
+
+    private func makeImageToolCallResult(_ result: AnyCodable) throws -> AnyCodable {
+        guard let payload = result.dictionaryValue else {
+            return try makeTextToolCallResult(
+                AnyCodable(["error": "Screenshot returned an invalid result"]),
+                isError: true
+            )
+        }
+
+        if payload["error"] != nil {
+            return try makeTextToolCallResult(result, isError: true)
+        }
+
+        guard let imageData = payload["image"]?.stringValue,
+              !imageData.isEmpty,
+              let format = payload["format"]?.stringValue,
+              format == "png" || format == "jpeg" else {
+            return try makeTextToolCallResult(
+                AnyCodable(["error": "Screenshot returned invalid image data or format"]),
+                isError: true
+            )
+        }
+
+        let metadata = payload
+            .filter { $0.key != "image" }
+            .mapValues(\.value)
+        let mimeType = format == "jpeg" ? "image/jpeg" : "image/png"
+
+        return AnyCodable([
+            "content": [
+                [
+                    "type": "image",
+                    "data": imageData,
+                    "mimeType": mimeType
+                ],
+                [
+                    "type": "text",
+                    "text": try jsonString(for: AnyCodable(metadata))
+                ]
+            ],
+            "structuredContent": metadata
+        ] as [String: Any])
+    }
+
+    private func jsonString(for value: AnyCodable) throws -> String {
+        let data = try JSONEncoder().encode(value)
+        return String(data: data, encoding: .utf8) ?? "{}"
     }
 }

--- a/ReactNative/appreveal/ios/MCPTools.swift
+++ b/ReactNative/appreveal/ios/MCPTools.swift
@@ -72,7 +72,7 @@ func registerBuiltInTools() {
 
     router.register(MCPToolDefinition(
         name: "screenshot",
-        description: "Capture a screenshot of the current screen. Returns base64-encoded image.",
+        description: "Capture a screenshot of the current screen. Returns a standard MCP image content block with dimensions and format metadata.",
         inputSchema: [
             "type": AnyCodable("object"),
             "properties": AnyCodable([
@@ -80,6 +80,7 @@ func registerBuiltInTools() {
                 "format": ["type": "string", "enum": ["png", "jpeg"], "description": "Image format (default: png)"]
             ] as [String: Any])
         ],
+        outputKind: .image,
         handler: { params in
             let format: ImageFormat = params?["format"]?.stringValue == "jpeg" ? .jpeg : .png
             let result: ScreenshotCapture.CaptureResult?
@@ -98,7 +99,7 @@ func registerBuiltInTools() {
                 "image": capture.imageData.base64EncodedString(),
                 "width": capture.width,
                 "height": capture.height,
-                "scale": capture.scale,
+                "scale": Double(capture.scale),
                 "format": capture.format
             ] as [String: Any])
         }
@@ -697,6 +698,16 @@ func registerBuiltInTools() {
 
                 guard let tool = router.tool(named: toolName) else {
                     results.append(["index": index, "tool": toolName, "error": "Tool not found"])
+                    if stopOnError { break }
+                    continue
+                }
+
+                if case .image = tool.outputKind {
+                    results.append([
+                        "index": index,
+                        "tool": toolName,
+                        "error": "Image tools cannot run inside batch. Call screenshot directly to receive an MCP image block."
+                    ])
                     if stopOnError { break }
                     continue
                 }

--- a/Windows/AppReveal.Windows/BuiltInTools.cs
+++ b/Windows/AppReveal.Windows/BuiltInTools.cs
@@ -44,7 +44,7 @@ internal static class BuiltInTools
         Register(router, "get_screen", "Get the currently active screen identity and metadata.", NoArgs(), (_, cancellationToken) => runtime.GetScreen(cancellationToken));
         Register(router, "get_elements", "List all visible interactive elements on the current screen.", ObjectSchema(("window_id", new JsonObject { ["type"] = "string" })), (args, cancellationToken) => runtime.GetElements(args, cancellationToken));
         Register(router, "get_view_tree", "Dump the view hierarchy with class, frame, properties, and accessibility info.", ObjectSchema(("window_id", new JsonObject { ["type"] = "string" }), ("max_depth", new JsonObject { ["type"] = "integer", ["minimum"] = 0, ["maximum"] = 200 })), (args, cancellationToken) => runtime.GetViewTree(args, cancellationToken));
-        Register(router, "screenshot", "Capture the screen or a single element as a base64 image.", ObjectSchema(("window_id", new JsonObject { ["type"] = "string" }), ("element_id", new JsonObject { ["type"] = "string" }), ("format", new JsonObject { ["type"] = "string", ["enum"] = new JsonArray("png", "jpeg") })), runtime.Screenshot);
+        Register(router, "screenshot", "Capture the screen or a single element as an MCP image content block.", ObjectSchema(("window_id", new JsonObject { ["type"] = "string" }), ("element_id", new JsonObject { ["type"] = "string" }), ("format", new JsonObject { ["type"] = "string", ["enum"] = new JsonArray("png", "jpeg") })), runtime.Screenshot);
 
         if (runtime.HasInteractionProvider)
         {
@@ -112,6 +112,11 @@ internal static class BuiltInTools
                     if (string.Equals(name, "batch", StringComparison.Ordinal))
                     {
                         throw new McpInvalidParamsException("batch cannot call batch");
+                    }
+
+                    if (string.Equals(name, "screenshot", StringComparison.Ordinal))
+                    {
+                        throw new McpInvalidParamsException("screenshot must be called directly to return MCP image content");
                     }
 
                     if (action.TryGetPropertyValue("arguments", out var argumentNode)

--- a/Windows/AppReveal.Windows/Mcp.cs
+++ b/Windows/AppReveal.Windows/Mcp.cs
@@ -129,18 +129,68 @@ internal sealed class McpRouter
 
         var arguments = parameters?["arguments"] as JsonObject;
         var result = await CallToolAsync(toolName, arguments, cancellationToken);
-        var text = JsonSerializer.Serialize(result, Json.Options);
+        return ToolCallResult(toolName, result);
+    }
+
+    private static JsonObject ToolCallResult(string toolName, JsonNode result)
+    {
+        if (!string.Equals(toolName, "screenshot", StringComparison.Ordinal)
+            || result is not JsonObject screenshot)
+        {
+            return TextToolResult(result);
+        }
+
+        var imageData = Json.ReadString(screenshot, "image");
+        if (string.IsNullOrWhiteSpace(imageData))
+        {
+            return TextToolResult(result, isError: true);
+        }
+
+        var format = Json.ReadString(screenshot, "format")?.Trim().ToLowerInvariant() ?? "png";
+        var mimeType = format is "jpeg" or "jpg" ? "image/jpeg" : "image/png";
+        var metadata = (JsonObject)screenshot.DeepClone();
+        metadata.Remove("image");
+
         return new JsonObject
         {
             ["content"] = new JsonArray
             {
                 new JsonObject
                 {
+                    ["type"] = "image",
+                    ["data"] = imageData,
+                    ["mimeType"] = mimeType
+                },
+                new JsonObject
+                {
                     ["type"] = "text",
-                    ["text"] = text
+                    ["text"] = metadata.ToJsonString(Json.Options)
+                }
+            },
+            ["structuredContent"] = metadata.DeepClone()
+        };
+    }
+
+    private static JsonObject TextToolResult(JsonNode result, bool isError = false)
+    {
+        var response = new JsonObject
+        {
+            ["content"] = new JsonArray
+            {
+                new JsonObject
+                {
+                    ["type"] = "text",
+                    ["text"] = JsonSerializer.Serialize(result, Json.Options)
                 }
             }
         };
+
+        if (isError)
+        {
+            response["isError"] = true;
+        }
+
+        return response;
     }
 
     private static JsonObject ToToolJson(McpTool tool)

--- a/Windows/appreveal-tauri/src/builtins.rs
+++ b/Windows/appreveal-tauri/src/builtins.rs
@@ -261,6 +261,19 @@ fn register_batch(registry: &ToolRegistry) -> Result<()> {
                     }
                 };
 
+                if tool_name == "screenshot" {
+                    push_batch_error(
+                        &mut results,
+                        index,
+                        Some(tool_name),
+                        "screenshot must be called directly to return MCP image content",
+                    );
+                    if stop_on_error {
+                        break;
+                    }
+                    continue;
+                }
+
                 let delay_ms = match parse_batch_delay_ms(action.get("delay_ms")) {
                     Ok(delay_ms) => delay_ms,
                     Err(error) => {
@@ -487,6 +500,26 @@ mod tests {
         assert_eq!(
             result["results"][0]["error"],
             json!("delay_ms must be a non-negative integer")
+        );
+    }
+
+    #[test]
+    fn batch_rejects_screenshot_with_direct_call_instruction() {
+        let registry = registry_with_builtins(ProviderRegistry::new());
+        let batch = registry.tool("batch").unwrap().unwrap();
+
+        let result = batch
+            .call(Some(&json!({
+                "actions": [
+                    { "tool": "screenshot" }
+                ]
+            })))
+            .unwrap();
+
+        assert_eq!(result["results"][0]["success"], false);
+        assert_eq!(
+            result["results"][0]["error"],
+            json!("screenshot must be called directly to return MCP image content")
         );
     }
 

--- a/Windows/appreveal-tauri/src/protocol.rs
+++ b/Windows/appreveal-tauri/src/protocol.rs
@@ -268,31 +268,85 @@ fn handle_tool_call(registry: &ToolRegistry, request: JsonRpcRequest) -> JsonRpc
         }
     };
 
-    match call_tool_text(&tool, arguments) {
-        Ok(content_text) => JsonRpcResponse::success(
-            id,
-            json!({
-                "content": [
-                    {
-                        "type": "text",
-                        "text": content_text
-                    }
-                ]
-            }),
-        ),
+    match tool
+        .call(arguments)
+        .and_then(|value| tool_call_result(tool_name, value))
+    {
+        Ok(result) => JsonRpcResponse::success(id, result),
         Err(error) => JsonRpcResponse::error(id, RpcError::internal_error(error.to_string())),
     }
 }
 
-fn call_tool_text(tool: &crate::registry::Tool, arguments: Option<&Value>) -> Result<String> {
-    let value = tool.call(arguments)?;
-    serde_json::to_string(&value).map_err(AppRevealError::from)
+fn tool_call_result(tool_name: &str, value: Value) -> Result<Value> {
+    if tool_name != "screenshot" {
+        return text_tool_result(value, false);
+    }
+
+    let Some(screenshot) = value.as_object() else {
+        return text_tool_result(value, true);
+    };
+    let Some(image_data) = screenshot
+        .get("image")
+        .and_then(Value::as_str)
+        .filter(|data| !data.trim().is_empty())
+    else {
+        return text_tool_result(value, true);
+    };
+
+    let format = screenshot
+        .get("format")
+        .and_then(Value::as_str)
+        .unwrap_or("png")
+        .to_ascii_lowercase();
+    let mime_type = if format == "jpeg" || format == "jpg" {
+        "image/jpeg"
+    } else {
+        "image/png"
+    };
+    let mut metadata = screenshot.clone();
+    metadata.remove("image");
+    let metadata = Value::Object(metadata);
+    let metadata_text = serde_json::to_string(&metadata).map_err(AppRevealError::from)?;
+
+    Ok(json!({
+        "content": [
+            {
+                "type": "image",
+                "data": image_data,
+                "mimeType": mime_type
+            },
+            {
+                "type": "text",
+                "text": metadata_text
+            }
+        ],
+        "structuredContent": metadata
+    }))
+}
+
+fn text_tool_result(value: Value, is_error: bool) -> Result<Value> {
+    serde_json::to_string(&value)
+        .map_err(AppRevealError::from)
+        .map(|text| {
+            let mut result = json!({
+                "content": [
+                    {
+                        "type": "text",
+                        "text": text
+                    }
+                ]
+            });
+            if is_error {
+                result["isError"] = json!(true);
+            }
+            result
+        })
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{registry_with_builtins, ProviderRegistry};
+    use crate::{registry_with_builtins, ProviderRegistry, Tool};
 
     #[test]
     fn initialize_returns_appreveal_server_info() {
@@ -341,6 +395,88 @@ mod tests {
             serde_json::from_str::<Value>(&text).unwrap(),
             json!({ "cartCount": 2 })
         );
+    }
+
+    #[test]
+    fn screenshot_returns_image_content_and_metadata() {
+        for (format, mime_type) in [("png", "image/png"), ("jpeg", "image/jpeg")] {
+            let registry = ToolRegistry::new();
+            registry
+                .register(Tool::new(
+                    "screenshot",
+                    "Screenshot",
+                    json!({ "type": "object" }),
+                    move |_| {
+                        Ok(json!({
+                            "image": format!("base64-{format}"),
+                            "width": 100,
+                            "height": 200,
+                            "scale": 2.0,
+                            "format": format
+                        }))
+                    },
+                ))
+                .unwrap();
+
+            let response = handle_request(
+                &registry,
+                JsonRpcRequest {
+                    jsonrpc: Some("2.0".to_string()),
+                    id: Some(json!(1)),
+                    method: "tools/call".to_string(),
+                    params: Some(json!({
+                        "name": "screenshot",
+                        "arguments": {}
+                    })),
+                },
+            );
+
+            let result = response.result.unwrap();
+            assert_eq!(result["content"][0]["type"], json!("image"));
+            assert_eq!(
+                result["content"][0]["data"],
+                json!(format!("base64-{format}"))
+            );
+            assert_eq!(result["content"][0]["mimeType"], json!(mime_type));
+            assert!(result["structuredContent"].get("image").is_none());
+            assert_eq!(result["structuredContent"]["width"], json!(100));
+            let metadata = result["content"][1]["text"].as_str().unwrap();
+            assert_eq!(
+                serde_json::from_str::<Value>(metadata).unwrap(),
+                result["structuredContent"]
+            );
+        }
+    }
+
+    #[test]
+    fn failed_screenshot_is_text_content_marked_as_error() {
+        let registry = ToolRegistry::new();
+        registry
+            .register(Tool::new(
+                "screenshot",
+                "Screenshot",
+                json!({ "type": "object" }),
+                |_| Ok(json!({ "error": "capture failed" })),
+            ))
+            .unwrap();
+
+        let response = handle_request(
+            &registry,
+            JsonRpcRequest {
+                jsonrpc: Some("2.0".to_string()),
+                id: Some(json!(1)),
+                method: "tools/call".to_string(),
+                params: Some(json!({
+                    "name": "screenshot",
+                    "arguments": {}
+                })),
+            },
+        );
+
+        let result = response.result.unwrap();
+        assert_eq!(result["content"][0]["type"], json!("text"));
+        assert_eq!(result["isError"], json!(true));
+        assert!(result.get("structuredContent").is_none());
     }
 
     #[test]

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -109,22 +109,38 @@ Each node includes `safeAreaInsets` and `safeAreaLayoutGuideFrame` alongside the
 ---
 
 ### `screenshot`
-Capture the screen or a single element as base64-encoded image.
+Capture the screen or a single element. The image is returned as a standard MCP image content block,
+so multimodal clients can display or inspect it without decoding JSON first.
 
 **Parameters:**
 - `element_id` (string, optional) — capture just this element
 - `format` (string, optional) — `"png"` (default) or `"jpeg"`
 
-**Response:**
+**Tool result:**
 ```json
 {
-  "image": "<base64>",
-  "width": 1206,
-  "height": 2622,
-  "scale": 3.0,
-  "format": "png"
+  "content": [
+    {
+      "type": "image",
+      "data": "<base64>",
+      "mimeType": "image/png"
+    },
+    {
+      "type": "text",
+      "text": "{\"width\":1206,\"height\":2622,\"scale\":3.0,\"format\":\"png\"}"
+    }
+  ],
+  "structuredContent": {
+    "width": 1206,
+    "height": 2622,
+    "scale": 3.0,
+    "format": "png"
+  }
 }
 ```
+
+The base64 data appears only in the image block. Metadata is repeated as text for clients that do
+not yet read `structuredContent`, following the MCP tool-result compatibility convention.
 
 ---
 
@@ -657,6 +673,9 @@ Execute multiple tool calls in a single request. Actions run sequentially.
 - `actions` (array, required) — each item: `{ "tool": "tool_name", "arguments": { ... }, "delay_ms": 500 }`
   - `delay_ms` — milliseconds to wait **before** this action (for animations, transitions, loading states)
 - `stop_on_error` (boolean, optional) — default false
+
+Call `screenshot` directly rather than inside `batch`; image content blocks cannot be embedded in a
+batch's JSON results.
 
 **Response:**
 ```json

--- a/example/Android/verify-compose-mcp.sh
+++ b/example/Android/verify-compose-mcp.sh
@@ -39,6 +39,9 @@ token="$(printf '%s' "$session_url" | sed -E 's#.*appreveal_session_token=([^[:s
 base_url="http://127.0.0.1:$port/"
 "$ADB" -s "$SERIAL" forward "tcp:$port" "tcp:$port" >/dev/null
 
+"$SCRIPT_DIR/../../scripts/verify-screenshot-mcp.sh" "$session_url" png
+"$SCRIPT_DIR/../../scripts/verify-screenshot-mcp.sh" "$session_url" jpeg
+
 call_tool() {
     local name="$1"
     local arguments="$2"

--- a/example/iOS/README.md
+++ b/example/iOS/README.md
@@ -65,3 +65,15 @@ open AppRevealExample.xcodeproj
 3. Drag all source folders into the project
 4. Set deployment target to iOS 16.0
 5. Build and run on simulator
+
+## Verify screenshot output
+
+Pass the session URL printed by the running example to the shared protocol check. It verifies the
+MCP image content block, structured metadata, and decoded image signature for both formats.
+
+```bash
+../../scripts/verify-screenshot-mcp.sh \
+  'http://127.0.0.1:<port>/?appreveal_session_token=<token>'
+../../scripts/verify-screenshot-mcp.sh \
+  'http://127.0.0.1:<port>/?appreveal_session_token=<token>' jpeg
+```

--- a/iOS/Sources/AppReveal/MCPServer/MCPRouter.swift
+++ b/iOS/Sources/AppReveal/MCPServer/MCPRouter.swift
@@ -8,11 +8,31 @@ typealias MCPToolHandler = @MainActor (
     _ params: [String: AnyCodable]?
 ) async throws -> AnyCodable
 
+enum MCPToolOutputKind {
+    case jsonText
+    case image
+}
+
 struct MCPToolDefinition {
     let name: String
     let description: String
     let inputSchema: [String: AnyCodable]
+    let outputKind: MCPToolOutputKind
     let handler: MCPToolHandler
+
+    init(
+        name: String,
+        description: String,
+        inputSchema: [String: AnyCodable],
+        outputKind: MCPToolOutputKind = .jsonText,
+        handler: @escaping MCPToolHandler
+    ) {
+        self.name = name
+        self.description = description
+        self.inputSchema = inputSchema
+        self.outputKind = outputKind
+        self.handler = handler
+    }
 }
 
 @MainActor
@@ -69,13 +89,10 @@ final class MCPRouter {
             do {
                 let arguments = params["arguments"]?.dictionaryValue
                 let result = try await tool.handler(arguments)
-                let resultData = try JSONEncoder().encode(result)
-                let resultString = String(data: resultData, encoding: .utf8) ?? "{}"
-                return MCPResponse(id: request.id, result: AnyCodable([
-                    "content": [
-                        ["type": "text", "text": resultString]
-                    ]
-                ] as [String: Any]))
+                return MCPResponse(
+                    id: request.id,
+                    result: try makeToolCallResult(result, outputKind: tool.outputKind)
+                )
             } catch {
                 return MCPResponse(id: request.id, error: .internalError(error.localizedDescription))
             }
@@ -83,6 +100,81 @@ final class MCPRouter {
         default:
             return MCPResponse(id: request.id, error: .methodNotFound(request.method))
         }
+    }
+
+    private func makeToolCallResult(
+        _ result: AnyCodable,
+        outputKind: MCPToolOutputKind
+    ) throws -> AnyCodable {
+        switch outputKind {
+        case .jsonText:
+            return try makeTextToolCallResult(result)
+        case .image:
+            return try makeImageToolCallResult(result)
+        }
+    }
+
+    private func makeTextToolCallResult(
+        _ result: AnyCodable,
+        isError: Bool = false
+    ) throws -> AnyCodable {
+        var payload: [String: Any] = [
+            "content": [
+                ["type": "text", "text": try jsonString(for: result)]
+            ]
+        ]
+        if isError {
+            payload["isError"] = true
+        }
+        return AnyCodable(payload)
+    }
+
+    private func makeImageToolCallResult(_ result: AnyCodable) throws -> AnyCodable {
+        guard let payload = result.dictionaryValue else {
+            return try makeTextToolCallResult(
+                AnyCodable(["error": "Screenshot returned an invalid result"]),
+                isError: true
+            )
+        }
+
+        if payload["error"] != nil {
+            return try makeTextToolCallResult(result, isError: true)
+        }
+
+        guard let imageData = payload["image"]?.stringValue,
+              !imageData.isEmpty,
+              let format = payload["format"]?.stringValue,
+              format == "png" || format == "jpeg" else {
+            return try makeTextToolCallResult(
+                AnyCodable(["error": "Screenshot returned invalid image data or format"]),
+                isError: true
+            )
+        }
+
+        let metadata = payload
+            .filter { $0.key != "image" }
+            .mapValues(\.value)
+        let mimeType = format == "jpeg" ? "image/jpeg" : "image/png"
+
+        return AnyCodable([
+            "content": [
+                [
+                    "type": "image",
+                    "data": imageData,
+                    "mimeType": mimeType
+                ],
+                [
+                    "type": "text",
+                    "text": try jsonString(for: AnyCodable(metadata))
+                ]
+            ],
+            "structuredContent": metadata
+        ] as [String: Any])
+    }
+
+    private func jsonString(for value: AnyCodable) throws -> String {
+        let data = try JSONEncoder().encode(value)
+        return String(data: data, encoding: .utf8) ?? "{}"
     }
 }
 

--- a/iOS/Sources/AppReveal/MCPServer/MCPTools.swift
+++ b/iOS/Sources/AppReveal/MCPServer/MCPTools.swift
@@ -418,6 +418,16 @@ func registerBuiltInTools() {
                     continue
                 }
 
+                if case .image = tool.outputKind {
+                    results.append([
+                        "index": index,
+                        "tool": toolName,
+                        "error": "Image tools cannot run inside batch. Call screenshot directly to receive an MCP image block."
+                    ])
+                    if stopOnError { break }
+                    continue
+                }
+
                 let arguments: [String: AnyCodable]?
                 if let args = action["arguments"] as? [String: Any] {
                     arguments = args.mapValues { AnyCodable($0) }
@@ -535,7 +545,7 @@ private func registerIOSBuiltInTools() {
 
     router.register(MCPToolDefinition(
         name: "screenshot",
-        description: "Capture a screenshot of the current screen. Returns base64-encoded image.",
+        description: "Capture a screenshot of the current screen. Returns a standard MCP image content block with dimensions and format metadata.",
         inputSchema: [
             "type": AnyCodable("object"),
             "properties": AnyCodable([
@@ -544,6 +554,7 @@ private func registerIOSBuiltInTools() {
                 "window_id": ["type": "string", "description": "Target window ID from list_windows (default: key window)"]
             ] as [String: Any])
         ],
+        outputKind: .image,
         handler: { params in
             let format: ImageFormat = params?["format"]?.stringValue == "jpeg" ? .jpeg : .png
             let windowId = params?["window_id"]?.stringValue
@@ -563,7 +574,7 @@ private func registerIOSBuiltInTools() {
                 "image": capture.imageData.base64EncodedString(),
                 "width": capture.width,
                 "height": capture.height,
-                "scale": capture.scale,
+                "scale": Double(capture.scale),
                 "format": capture.format
             ] as [String: Any])
         }

--- a/iOS/Sources/AppReveal/MCPServer/MacOSMCPTools.swift
+++ b/iOS/Sources/AppReveal/MCPServer/MacOSMCPTools.swift
@@ -75,11 +75,12 @@ func registerMacOSBuiltInToolsImpl() {
 
     router.register(MCPToolDefinition(
         name: "screenshot",
-        description: "Capture a screenshot of the current screen. Returns base64-encoded image.",
+        description: "Capture a screenshot of the current screen. Returns a standard MCP image content block with dimensions and format metadata.",
         inputSchema: macOSInputSchema([
             "element_id": ["type": "string", "description": "Optional element ID to crop to"],
             "format": ["type": "string", "enum": ["png", "jpeg"], "description": "Image format (default: png)"]
         ]),
+        outputKind: .image,
         handler: { params in
             let format: ImageFormat = params?["format"]?.stringValue == "jpeg" ? .jpeg : .png
             let windowId = params?["window_id"]?.stringValue
@@ -99,7 +100,7 @@ func registerMacOSBuiltInToolsImpl() {
                 "image": capture.imageData.base64EncodedString(),
                 "width": capture.width,
                 "height": capture.height,
-                "scale": capture.scale,
+                "scale": Double(capture.scale),
                 "format": capture.format
             ] as [String: Any])
         }

--- a/iOS/Tests/AppRevealTests/MCPRouterTests.swift
+++ b/iOS/Tests/AppRevealTests/MCPRouterTests.swift
@@ -1,0 +1,150 @@
+import XCTest
+@testable import AppReveal
+
+#if DEBUG
+
+@MainActor
+final class MCPRouterTests: XCTestCase {
+
+    func testImageToolReturnsMCPImageBlockAndMetadata() async throws {
+        let imageData = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
+        let toolName = "test_image_result"
+        MCPRouter.shared.register(MCPToolDefinition(
+            name: toolName,
+            description: "Test image",
+            inputSchema: emptySchema,
+            outputKind: .image,
+            handler: { _ in
+                AnyCodable([
+                    "image": imageData,
+                    "width": 120,
+                    "height": 240,
+                    "scale": 2.0,
+                    "format": "png"
+                ] as [String: Any])
+            }
+        ))
+
+        let response = await MCPRouter.shared.handle(toolRequest(name: toolName))
+        let result = try resultObject(from: response)
+        let content = try XCTUnwrap(result["content"] as? [[String: Any]])
+
+        XCTAssertEqual(content.count, 2)
+        XCTAssertEqual(content[0]["type"] as? String, "image")
+        XCTAssertEqual(content[0]["data"] as? String, imageData)
+        XCTAssertEqual(content[0]["mimeType"] as? String, "image/png")
+        XCTAssertEqual(content[1]["type"] as? String, "text")
+
+        let metadataText = try XCTUnwrap(content[1]["text"] as? String)
+        XCTAssertFalse(metadataText.contains(imageData))
+        let metadataData = try XCTUnwrap(metadataText.data(using: .utf8))
+        let metadataFromText = try XCTUnwrap(
+            JSONSerialization.jsonObject(with: metadataData) as? [String: Any]
+        )
+        XCTAssertEqual(metadataFromText["width"] as? Int, 120)
+        XCTAssertEqual(metadataFromText["format"] as? String, "png")
+        XCTAssertNil(metadataFromText["image"])
+
+        let structuredContent = try XCTUnwrap(result["structuredContent"] as? [String: Any])
+        XCTAssertEqual(structuredContent["height"] as? Int, 240)
+        XCTAssertEqual(structuredContent["scale"] as? Double, 2.0)
+        XCTAssertNil(structuredContent["image"])
+        XCTAssertNil(result["isError"])
+    }
+
+    func testImageToolMapsJPEGMimeType() async throws {
+        let toolName = "test_jpeg_result"
+        MCPRouter.shared.register(MCPToolDefinition(
+            name: toolName,
+            description: "Test JPEG",
+            inputSchema: emptySchema,
+            outputKind: .image,
+            handler: { _ in
+                AnyCodable([
+                    "image": "/9j/4AAQSkZJRgABAQAAAQABAAD",
+                    "width": 20,
+                    "height": 10,
+                    "scale": 1.0,
+                    "format": "jpeg"
+                ] as [String: Any])
+            }
+        ))
+
+        let response = await MCPRouter.shared.handle(toolRequest(name: toolName))
+        let result = try resultObject(from: response)
+        let content = try XCTUnwrap(result["content"] as? [[String: Any]])
+
+        XCTAssertEqual(content[0]["mimeType"] as? String, "image/jpeg")
+    }
+
+    func testImageToolFailureReturnsTextError() async throws {
+        let toolName = "test_image_failure"
+        MCPRouter.shared.register(MCPToolDefinition(
+            name: toolName,
+            description: "Test image failure",
+            inputSchema: emptySchema,
+            outputKind: .image,
+            handler: { _ in
+                AnyCodable(["error": "Capture failed"])
+            }
+        ))
+
+        let response = await MCPRouter.shared.handle(toolRequest(name: toolName))
+        let result = try resultObject(from: response)
+        let content = try XCTUnwrap(result["content"] as? [[String: Any]])
+
+        XCTAssertEqual(content.count, 1)
+        XCTAssertEqual(content[0]["type"] as? String, "text")
+        XCTAssertTrue((content[0]["text"] as? String)?.contains("Capture failed") == true)
+        XCTAssertEqual(result["isError"] as? Bool, true)
+        XCTAssertNil(result["structuredContent"])
+    }
+
+    func testJSONToolKeepsTextResultShape() async throws {
+        let toolName = "test_json_result"
+        MCPRouter.shared.register(MCPToolDefinition(
+            name: toolName,
+            description: "Test JSON",
+            inputSchema: emptySchema,
+            handler: { _ in
+                AnyCodable(["value": "ok"])
+            }
+        ))
+
+        let response = await MCPRouter.shared.handle(toolRequest(name: toolName))
+        let result = try resultObject(from: response)
+        let content = try XCTUnwrap(result["content"] as? [[String: Any]])
+
+        XCTAssertEqual(content.count, 1)
+        XCTAssertEqual(content[0]["type"] as? String, "text")
+        XCTAssertEqual(content[0]["text"] as? String, "{\"value\":\"ok\"}")
+        XCTAssertNil(result["structuredContent"])
+    }
+
+    private var emptySchema: [String: AnyCodable] {
+        [
+            "type": AnyCodable("object"),
+            "properties": AnyCodable([String: Any]())
+        ]
+    }
+
+    private func toolRequest(name: String) -> MCPRequest {
+        MCPRequest(
+            jsonrpc: "2.0",
+            id: .int(1),
+            method: "tools/call",
+            params: [
+                "name": AnyCodable(name),
+                "arguments": AnyCodable([String: Any]())
+            ]
+        )
+    }
+
+    private func resultObject(from response: MCPResponse) throws -> [String: Any] {
+        let data = try JSONEncoder().encode(response)
+        let root = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        return try XCTUnwrap(root["result"] as? [String: Any])
+    }
+}
+
+#endif

--- a/scripts/verify-screenshot-mcp.sh
+++ b/scripts/verify-screenshot-mcp.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+session_url="${1:-${APPREVEAL_SESSION_URL:-}}"
+format="${2:-png}"
+
+if [[ -z "$session_url" ]]; then
+    printf 'Usage: %s <AppReveal session URL> [png|jpeg]\n' "$0" >&2
+    exit 2
+fi
+
+case "$format" in
+    png)
+        expected_mime="image/png"
+        expected_magic="89504e470d0a1a0a"
+        ;;
+    jpeg)
+        expected_mime="image/jpeg"
+        expected_magic="ffd8"
+        ;;
+    *)
+        printf 'Format must be png or jpeg\n' >&2
+        exit 2
+        ;;
+esac
+
+endpoint="${session_url%%\?*}"
+token="$(printf '%s' "$session_url" | sed -E 's#.*[?&]appreveal_session_token=([^&[:space:]]+).*#\1#')"
+if [[ -z "$token" || "$token" == "$session_url" ]]; then
+    printf 'Session URL does not contain appreveal_session_token\n' >&2
+    exit 2
+fi
+
+response_file="$(mktemp)"
+decoded_file="$(mktemp)"
+trap 'rm -f "$response_file" "$decoded_file"' EXIT
+
+curl -fsS "$endpoint" \
+    -H "Authorization: Bearer $token" \
+    -H 'Content-Type: application/json' \
+    -d "{\"jsonrpc\":\"2.0\",\"id\":1,\"method\":\"tools/call\",\"params\":{\"name\":\"screenshot\",\"arguments\":{\"format\":\"$format\"}}}" \
+    >"$response_file"
+
+jq -e \
+    --arg mime "$expected_mime" \
+    '.result.content[0].type == "image" and
+     .result.content[0].mimeType == $mime and
+     (.result.content[0].data | type == "string" and length > 0) and
+     .result.content[1].type == "text" and
+     ((.result.content[1].text | fromjson) == .result.structuredContent) and
+     (.result.structuredContent.image == null)' \
+    "$response_file" >/dev/null
+
+jq -r '.result.content[0].data' "$response_file" | openssl base64 -d -A >"$decoded_file"
+actual_magic="$(od -An -tx1 -N8 "$decoded_file" | tr -d '[:space:]')"
+if [[ "$actual_magic" != "$expected_magic"* ]]; then
+    printf 'Screenshot bytes do not match %s (magic: %s)\n' "$format" "$actual_magic" >&2
+    exit 1
+fi
+
+width="$(jq -r '.result.structuredContent.width' "$response_file")"
+height="$(jq -r '.result.structuredContent.height' "$response_file")"
+printf 'Screenshot MCP image block verified: %sx%s %s\n' "$width" "$height" "$expected_mime"


### PR DESCRIPTION
Fixes #49

Summary:
- return screenshot captures as MCP image content followed by compatible text metadata and structuredContent
- keep base64 out of metadata, mark capture failures with isError, and reject screenshot inside batch with direct-call guidance
- emit real JPEG bytes on Flutter and preserve PNG/JPEG MIME types on every platform
- add router tests, decoded-image protocol verification, documentation, and CI coverage for Swift, Android, Flutter, .NET Windows, and Tauri

Verification:
- reproduced the old text-only JSON/base64 response on iOS Simulator and Android Emulator before changing code
- live iOS Simulator PNG and JPEG: 1206x2622, decoded signatures verified
- live Android API 35 Emulator PNG and JPEG: 1080x2264, decoded signatures verified; full Compose MCP flow passed
- SwiftPM: 12 tests passed; SwiftLint strict: 0 violations
- Android unit tests, ktlint, lint, library build, and example build passed
- React Native Android unit/build and React Native iOS simulator-SDK type-check passed
- Flutter analyze and all 33 tests passed
- .NET Windows library cross-target build passed with 0 warnings/errors
- Tauri 27 tests passed serially; cargo fmt check passed

The PR remains draft until every required GitHub check is green.