### PR TITLE
Fix Android OkHttp network inspector

### DIFF
--- a/Android/appreveal-noop/build.gradle.kts
+++ b/Android/appreveal-noop/build.gradle.kts
@@ -24,5 +24,7 @@ android {
 }
 
 dependencies {
-    // Intentionally empty: release builds expose no diagnostics server.
+    // Release builds expose no diagnostics server. OkHttp is compile-only so apps can share
+    // debug/release networking setup without pulling AppReveal into release artifacts.
+    compileOnly("com.squareup.okhttp3:okhttp:4.12.0")
 }

--- a/Android/appreveal-noop/src/main/kotlin/com/appreveal/AppRevealOkHttp.kt
+++ b/Android/appreveal-noop/src/main/kotlin/com/appreveal/AppRevealOkHttp.kt
@@ -1,0 +1,18 @@
+package com.appreveal
+
+import com.appreveal.network.NetworkCaptureConfig
+import okhttp3.Interceptor
+import okhttp3.OkHttpClient
+
+object AppRevealOkHttp {
+    @JvmStatic
+    @JvmOverloads
+    fun install(
+        builder: OkHttpClient.Builder,
+        config: NetworkCaptureConfig = NetworkCaptureConfig(),
+    ): OkHttpClient.Builder = builder
+
+    @JvmStatic
+    @JvmOverloads
+    fun interceptor(config: NetworkCaptureConfig = NetworkCaptureConfig()): Interceptor = Interceptor { chain -> chain.proceed(chain.request()) }
+}

--- a/Android/appreveal-noop/src/main/kotlin/com/appreveal/network/NetworkCaptureConfig.kt
+++ b/Android/appreveal-noop/src/main/kotlin/com/appreveal/network/NetworkCaptureConfig.kt
@@ -1,0 +1,20 @@
+package com.appreveal.network
+
+data class NetworkCaptureConfig(
+    val maxBodyBytes: Long = 256L * 1024L,
+    val maxSSEEvents: Int = 200,
+    val redactedHeaders: Set<String> = defaultSensitiveHeaders,
+    val captureBodies: Boolean = true,
+) {
+    companion object {
+        val defaultSensitiveHeaders =
+            setOf(
+                "authorization",
+                "cookie",
+                "set-cookie",
+                "x-api-key",
+                "x-auth-token",
+                "proxy-authorization",
+            )
+    }
+}

--- a/Android/appreveal/build.gradle.kts
+++ b/Android/appreveal/build.gradle.kts
@@ -33,5 +33,10 @@ dependencies {
     implementation("androidx.recyclerview:recyclerview:1.3.2")
     implementation("com.google.android.material:material:1.11.0")
     implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+    compileOnly("com.squareup.okhttp3:okhttp:4.12.0")
+    compileOnly("com.squareup.okio:okio:3.6.0")
     testImplementation("junit:junit:4.13.2")
+    testImplementation("com.squareup.okhttp3:okhttp:4.12.0")
+    testImplementation("com.squareup.okhttp3:mockwebserver:4.12.0")
+    testImplementation("com.squareup.okio:okio:3.6.0")
 }

--- a/Android/appreveal/src/main/kotlin/com/appreveal/AppRevealOkHttp.kt
+++ b/Android/appreveal/src/main/kotlin/com/appreveal/AppRevealOkHttp.kt
@@ -1,0 +1,422 @@
+package com.appreveal
+
+import com.appreveal.network.CapturedRequest
+import com.appreveal.network.CapturedSSEEvent
+import com.appreveal.network.NetworkCaptureConfig
+import com.appreveal.network.NetworkObserverService
+import okhttp3.Headers
+import okhttp3.Interceptor
+import okhttp3.MediaType
+import okhttp3.OkHttpClient
+import okhttp3.RequestBody
+import okhttp3.Response
+import okhttp3.ResponseBody
+import okio.Buffer
+import okio.BufferedSource
+import okio.Source
+import okio.Timeout
+import okio.buffer
+import java.io.ByteArrayOutputStream
+import java.io.IOException
+import java.nio.charset.Charset
+import java.util.UUID
+
+/**
+ * Optional OkHttp integration for automatic AppReveal network capture.
+ *
+ * Install on the app's debug OkHttpClient builder:
+ * `AppRevealOkHttp.install(builder)`.
+ */
+object AppRevealOkHttp {
+    @JvmStatic
+    @JvmOverloads
+    fun install(
+        builder: OkHttpClient.Builder,
+        config: NetworkCaptureConfig = NetworkCaptureConfig(),
+    ): OkHttpClient.Builder = builder.addInterceptor(interceptor(config))
+
+    @JvmStatic
+    @JvmOverloads
+    fun interceptor(config: NetworkCaptureConfig = NetworkCaptureConfig()): Interceptor = NetworkCaptureInterceptor(config)
+}
+
+private class NetworkCaptureInterceptor(
+    private val config: NetworkCaptureConfig,
+) : Interceptor {
+    override fun intercept(chain: Interceptor.Chain): Response {
+        val request = chain.request()
+        val id = UUID.randomUUID().toString()
+        val startTime = System.currentTimeMillis()
+        val requestSnapshot = request.body.capture(config)
+
+        NetworkObserverService.addCall(
+            CapturedRequest(
+                id = id,
+                method = request.method,
+                url = request.url.toString(),
+                startTime = startTime,
+                requestHeaders = request.headers.toMap(),
+                requestBodySize = requestSnapshot.size,
+                requestBody = requestSnapshot.body,
+                requestBodyTruncated = requestSnapshot.truncated,
+            ).withRedactedHeaders(config.redactedHeaders),
+        )
+
+        return try {
+            val response = chain.proceed(request)
+            captureResponse(id, startTime, response)
+        } catch (error: IOException) {
+            NetworkObserverService.updateCall(id) { existing ->
+                existing.copy(
+                    endTime = System.currentTimeMillis(),
+                    duration = elapsedSeconds(startTime),
+                    error = error.message ?: error.javaClass.simpleName,
+                )
+            }
+            throw error
+        }
+    }
+
+    private fun captureResponse(
+        id: String,
+        startTime: Long,
+        response: Response,
+    ): Response {
+        val responseBody = response.body
+        val mediaType = responseBody?.contentType()
+        val streaming = response.isStreaming(mediaType)
+
+        NetworkObserverService.updateCall(id) { existing ->
+            existing.copy(
+                statusCode = response.code,
+                responseHeaders = response.headers.toMap(),
+                responseBodySize = responseBody?.contentLength()?.takeIf { it >= 0 }?.coerceToInt(),
+                isStreaming = streaming,
+                redirectCount = response.priorResponseCount(),
+                endTime = if (responseBody == null) System.currentTimeMillis() else existing.endTime,
+                duration = if (responseBody == null) elapsedSeconds(startTime) else existing.duration,
+            )
+        }
+
+        if (responseBody == null) {
+            return response
+        }
+
+        val wrappedBody =
+            CapturingResponseBody(
+                id = id,
+                startTime = startTime,
+                delegate = responseBody,
+                config = config,
+                captureText = config.captureBodies && mediaType.isTextLike(),
+                parseSSE = streaming,
+            )
+        return response.newBuilder().body(wrappedBody).build()
+    }
+}
+
+private class CapturingResponseBody(
+    private val id: String,
+    private val startTime: Long,
+    private val delegate: ResponseBody,
+    private val config: NetworkCaptureConfig,
+    private val captureText: Boolean,
+    parseSSE: Boolean,
+) : ResponseBody() {
+    private val accumulator = BodyAccumulator(config.maxBodyBytes, captureText, delegate.contentType())
+    private val sseParser = if (parseSSE) SSEEventAccumulator(config.maxSSEEvents) else null
+    private var bufferedSource: BufferedSource? = null
+
+    override fun contentLength(): Long = delegate.contentLength()
+
+    override fun contentType(): MediaType? = delegate.contentType()
+
+    override fun source(): BufferedSource {
+        if (bufferedSource == null) {
+            bufferedSource =
+                CapturingSource(
+                    delegate = delegate.source(),
+                    onBytes = ::captureBytes,
+                    onComplete = ::complete,
+                ).buffer()
+        }
+        return bufferedSource!!
+    }
+
+    private fun captureBytes(bytes: ByteArray) {
+        accumulator.append(bytes)
+        val sseEvents = sseParser?.append(bytes, delegate.contentType())
+
+        NetworkObserverService.updateCall(id) { existing ->
+            existing.copy(
+                responseBodySize = accumulator.totalBytes.coerceToInt(),
+                responseBody = accumulator.body,
+                responseBodyTruncated = accumulator.truncated,
+                sseEvents = sseEvents ?: existing.sseEvents,
+            )
+        }
+    }
+
+    private fun complete(error: IOException?) {
+        val finalEvents = sseParser?.finish()
+        NetworkObserverService.updateCall(id) { existing ->
+            existing.copy(
+                endTime = System.currentTimeMillis(),
+                duration = elapsedSeconds(startTime),
+                responseBodySize = accumulator.totalBytes.coerceToInt(),
+                responseBody = accumulator.body,
+                responseBodyTruncated = accumulator.truncated,
+                sseEvents = finalEvents ?: existing.sseEvents,
+                error = error?.message ?: existing.error,
+            )
+        }
+    }
+}
+
+private class CapturingSource(
+    private val delegate: Source,
+    private val onBytes: (ByteArray) -> Unit,
+    private val onComplete: (IOException?) -> Unit,
+) : Source {
+    private var completed = false
+
+    override fun read(
+        sink: Buffer,
+        byteCount: Long,
+    ): Long {
+        val buffer = Buffer()
+        return try {
+            val read = delegate.read(buffer, byteCount)
+            if (read > 0) {
+                val bytes = buffer.clone().readByteArray()
+                sink.write(buffer, read)
+                onBytes(bytes)
+            } else if (read == -1L) {
+                complete(null)
+            }
+            read
+        } catch (error: IOException) {
+            complete(error)
+            throw error
+        }
+    }
+
+    override fun timeout(): Timeout = delegate.timeout()
+
+    override fun close() {
+        try {
+            delegate.close()
+        } finally {
+            complete(null)
+        }
+    }
+
+    private fun complete(error: IOException?) {
+        if (!completed) {
+            completed = true
+            onComplete(error)
+        }
+    }
+}
+
+private data class BodySnapshot(
+    val size: Int?,
+    val body: String?,
+    val truncated: Boolean,
+)
+
+private fun RequestBody?.capture(config: NetworkCaptureConfig): BodySnapshot {
+    if (this == null) return BodySnapshot(size = null, body = null, truncated = false)
+
+    val knownSize = runCatching { contentLength().takeIf { it >= 0 }?.coerceToInt() }.getOrNull()
+    if (!config.captureBodies || isDuplex() || isOneShot() || !contentType().isTextLike()) {
+        return BodySnapshot(size = knownSize, body = null, truncated = false)
+    }
+
+    return runCatching {
+        val buffer = Buffer()
+        writeTo(buffer)
+        val totalSize = buffer.size
+        val snapshotSize = minOf(totalSize, config.maxBodyBytes.coerceAtLeast(0))
+        val bytes = buffer.readByteArray(snapshotSize)
+        BodySnapshot(
+            size = totalSize.coerceToInt(),
+            body = String(bytes, contentType().charsetOrUtf8()),
+            truncated = totalSize > snapshotSize,
+        )
+    }.getOrElse {
+        BodySnapshot(size = knownSize, body = null, truncated = false)
+    }
+}
+
+private class BodyAccumulator(
+    private val maxBodyBytes: Long,
+    private val captureText: Boolean,
+    private val mediaType: MediaType?,
+) {
+    private val output = ByteArrayOutputStream()
+    var totalBytes: Long = 0
+        private set
+    var truncated: Boolean = false
+        private set
+
+    val body: String?
+        get() {
+            if (!captureText) return null
+            return String(output.toByteArray(), mediaType.charsetOrUtf8())
+        }
+
+    fun append(bytes: ByteArray) {
+        totalBytes += bytes.size
+        if (!captureText) return
+
+        val remaining = maxBodyBytes.coerceAtLeast(0) - output.size()
+        if (remaining <= 0) {
+            truncated = truncated || bytes.isNotEmpty()
+            return
+        }
+
+        val toWrite = minOf(bytes.size.toLong(), remaining).toInt()
+        output.write(bytes, 0, toWrite)
+        if (toWrite < bytes.size) truncated = true
+    }
+}
+
+private class SSEEventAccumulator(
+    private val maxEvents: Int,
+) {
+    private val events = mutableListOf<CapturedSSEEvent>()
+    private var lineBuffer = StringBuilder()
+    private var dataLines = mutableListOf<String>()
+    private var eventName: String? = null
+    private var eventId: String? = null
+    private var retry: Long? = null
+
+    fun append(
+        bytes: ByteArray,
+        mediaType: MediaType?,
+    ): List<CapturedSSEEvent> {
+        lineBuffer.append(String(bytes, mediaType.charsetOrUtf8()))
+        drainLines()
+        return events.toList()
+    }
+
+    fun finish(): List<CapturedSSEEvent> {
+        if (lineBuffer.isNotEmpty()) {
+            handleLine(lineBuffer.toString())
+            lineBuffer = StringBuilder()
+        }
+        emitIfNeeded()
+        return events.toList()
+    }
+
+    private fun drainLines() {
+        while (true) {
+            val lineEnd = lineBuffer.indexOfFirstNewline()
+            if (lineEnd == -1) return
+
+            var line = lineBuffer.substring(0, lineEnd)
+            val newlineLength =
+                if (lineBuffer.getOrNull(lineEnd) == '\r' && lineBuffer.getOrNull(lineEnd + 1) == '\n') {
+                    2
+                } else {
+                    1
+                }
+            lineBuffer.delete(0, lineEnd + newlineLength)
+            if (line.endsWith('\r')) line = line.dropLast(1)
+            handleLine(line)
+        }
+    }
+
+    private fun handleLine(line: String) {
+        if (line.isEmpty()) {
+            emitIfNeeded()
+            return
+        }
+        if (line.startsWith(":")) return
+
+        val separator = line.indexOf(':')
+        val field = if (separator == -1) line else line.substring(0, separator)
+        val rawValue = if (separator == -1) "" else line.substring(separator + 1)
+        val value = if (rawValue.startsWith(" ")) rawValue.drop(1) else rawValue
+
+        when (field) {
+            "data" -> dataLines.add(value)
+            "event" -> eventName = value
+            "id" -> eventId = value
+            "retry" -> retry = value.toLongOrNull()
+        }
+    }
+
+    private fun emitIfNeeded() {
+        if (dataLines.isEmpty() && eventName == null && eventId == null && retry == null) return
+
+        events.add(
+            CapturedSSEEvent(
+                id = eventId,
+                event = eventName ?: "message",
+                data = dataLines.joinToString("\n"),
+                retry = retry,
+            ),
+        )
+        while (events.size > maxEvents.coerceAtLeast(0)) {
+            events.removeAt(0)
+        }
+
+        dataLines = mutableListOf()
+        eventName = null
+        eventId = null
+        retry = null
+    }
+}
+
+private fun Headers.toMap(): Map<String, String> = names().associateWith { name -> values(name).joinToString(", ") }
+
+private fun Response.isStreaming(mediaType: MediaType?): Boolean {
+    val contentType = mediaType?.toString()?.lowercase().orEmpty()
+    val cacheControl = header("Cache-Control").orEmpty().lowercase()
+    return contentType.contains("text/event-stream") ||
+        header("X-Accel-Buffering").equals("no", ignoreCase = true) ||
+        cacheControl.contains("no-transform")
+}
+
+private fun Response.priorResponseCount(): Int {
+    var count = 0
+    var current = priorResponse
+    while (current != null) {
+        count += 1
+        current = current.priorResponse
+    }
+    return count
+}
+
+private fun MediaType?.isTextLike(): Boolean {
+    val value = this?.toString()?.lowercase() ?: return false
+    return value.startsWith("text/") ||
+        value.contains("json") ||
+        value.contains("xml") ||
+        value.contains("x-www-form-urlencoded") ||
+        value.contains("graphql") ||
+        value.contains("event-stream")
+}
+
+private fun MediaType?.charsetOrUtf8(): Charset = this?.charset(Charsets.UTF_8) ?: Charsets.UTF_8
+
+private fun Long.coerceToInt(): Int =
+    when {
+        this > Int.MAX_VALUE -> Int.MAX_VALUE
+        this < Int.MIN_VALUE -> Int.MIN_VALUE
+        else -> toInt()
+    }
+
+private fun elapsedSeconds(startTime: Long): Double = (System.currentTimeMillis() - startTime) / 1000.0
+
+private fun StringBuilder.indexOfFirstNewline(): Int {
+    val lf = indexOf("\n")
+    val cr = indexOf("\r")
+    return when {
+        lf == -1 -> cr
+        cr == -1 -> lf
+        else -> minOf(lf, cr)
+    }
+}

--- a/Android/appreveal/src/main/kotlin/com/appreveal/mcpserver/MCPTools.kt
+++ b/Android/appreveal/src/main/kotlin/com/appreveal/mcpserver/MCPTools.kt
@@ -7,6 +7,8 @@ import androidx.core.content.pm.PackageInfoCompat
 import com.appreveal.diagnostics.DiagnosticsBridge
 import com.appreveal.elements.ElementInventory
 import com.appreveal.interaction.InteractionEngine
+import com.appreveal.network.CapturedRequest
+import com.appreveal.network.CapturedSSEEvent
 import com.appreveal.network.NetworkObserverService
 import com.appreveal.screen.ScreenResolver
 import com.appreveal.screenshot.ScreenshotCapture
@@ -537,28 +539,42 @@ internal fun registerBuiltInTools() {
     router.register(
         MCPToolDefinition(
             name = "get_network_calls",
-            description = "Get recent network calls",
+            description = "List recent network calls captured by AppReveal",
             inputSchema = jsonSchema("limit" to jsonProp("integer", "Max results (default 50)")),
             handler = { params ->
                 val limit = params?.get("limit")?.asIntOrNull() ?: 50
                 val calls = NetworkObserverService.recentCalls(limit)
                 val list = JsonArray()
                 for (call in calls) {
-                    list.add(
-                        JsonObject().apply {
-                            addProperty("id", call.id)
-                            addProperty("method", call.method)
-                            addProperty("url", call.url)
-                            addProperty("statusCode", call.statusCode?.toString() ?: "nil")
-                            addProperty("duration", call.duration?.let { String.format("%.3fs", it) } ?: "nil")
-                            addProperty("error", call.error ?: "")
-                        },
-                    )
+                    list.add(call.toNetworkSummaryJson())
                 }
                 JsonObject().apply {
                     add("calls", list)
                     addProperty("count", list.size())
                 }
+            },
+        ),
+    )
+
+    // -- get_network_call_detail --
+
+    router.register(
+        MCPToolDefinition(
+            name = "get_network_call_detail",
+            description = "Get headers, body previews, and SSE frames for one captured network call",
+            inputSchema =
+                jsonSchema(
+                    "id" to jsonProp("string", "Network call id from get_network_calls"),
+                    required = listOf("id"),
+                ),
+            handler = { params ->
+                val id =
+                    params?.get("id")?.asStringOrNull()
+                        ?: return@MCPToolDefinition errorResult("id required")
+                val call =
+                    NetworkObserverService.callDetail(id)
+                        ?: return@MCPToolDefinition errorResult("Network call not found: $id")
+                call.toNetworkDetailJson()
             },
         ),
     )
@@ -1027,6 +1043,95 @@ internal fun registerBuiltInTools() {
 // -- Helper functions --
 
 private fun errorResult(message: String): JsonElement = JsonObject().apply { addProperty("error", message) }
+
+private fun CapturedRequest.toNetworkSummaryJson(): JsonObject =
+    JsonObject().apply {
+        addProperty("id", id)
+        addProperty("method", method)
+        addProperty("url", url)
+        addNullableNumber("statusCode", statusCode)
+        addProperty("startTime", startTime)
+        addNullableNumber("endTime", endTime)
+        addNullableNumber("durationMs", duration?.let { (it * 1000).toLong() })
+        addProperty("duration", duration?.let { String.format("%.3fs", it) } ?: "nil")
+        addNullableNumber("requestBodySize", requestBodySize)
+        addNullableNumber("responseBodySize", responseBodySize)
+        addProperty("requestBodyTruncated", requestBodyTruncated)
+        addProperty("responseBodyTruncated", responseBodyTruncated)
+        addProperty("isStreaming", isStreaming)
+        addProperty("sseEventCount", sseEvents.size)
+        addProperty("complete", endTime != null)
+        addProperty("error", error ?: "")
+    }
+
+private fun CapturedRequest.toNetworkDetailJson(): JsonObject =
+    toNetworkSummaryJson().apply {
+        addProperty("redirectCount", redirectCount)
+        add(
+            "request",
+            JsonObject().apply {
+                add("headers", requestHeaders.toStringJsonObject())
+                addNullableString("body", requestBody)
+                addNullableNumber("bodySize", requestBodySize)
+                addProperty("bodyTruncated", requestBodyTruncated)
+            },
+        )
+        add(
+            "response",
+            JsonObject().apply {
+                add("headers", responseHeaders?.toStringJsonObject() ?: JsonObject())
+                addNullableString("body", responseBody)
+                addNullableNumber("bodySize", responseBodySize)
+                addProperty("bodyTruncated", responseBodyTruncated)
+            },
+        )
+        add("sseEvents", sseEvents.toSSEJsonArray())
+    }
+
+private fun List<CapturedSSEEvent>.toSSEJsonArray(): JsonArray {
+    val arr = JsonArray()
+    for (event in this) {
+        arr.add(
+            JsonObject().apply {
+                addNullableString("id", event.id)
+                addNullableString("event", event.event)
+                addProperty("data", event.data)
+                addNullableNumber("retry", event.retry)
+                addProperty("timestamp", event.timestamp)
+            },
+        )
+    }
+    return arr
+}
+
+private fun Map<String, String>.toStringJsonObject(): JsonObject =
+    JsonObject().apply {
+        for ((key, value) in this@toStringJsonObject) {
+            addProperty(key, value)
+        }
+    }
+
+private fun JsonObject.addNullableString(
+    property: String,
+    value: String?,
+) {
+    if (value == null) {
+        add(property, com.google.gson.JsonNull.INSTANCE)
+    } else {
+        addProperty(property, value)
+    }
+}
+
+private fun JsonObject.addNullableNumber(
+    property: String,
+    value: Number?,
+) {
+    if (value == null) {
+        add(property, com.google.gson.JsonNull.INSTANCE)
+    } else {
+        addProperty(property, value)
+    }
+}
 
 private fun jsonProp(
     type: String,

--- a/Android/appreveal/src/main/kotlin/com/appreveal/network/CapturedRequest.kt
+++ b/Android/appreveal/src/main/kotlin/com/appreveal/network/CapturedRequest.kt
@@ -1,7 +1,28 @@
 package com.appreveal.network
 
 /**
- * Captured network request data. Matches iOS CapturedRequest exactly.
+ * Captured Server-Sent Event frame.
+ */
+data class CapturedSSEEvent(
+    val id: String? = null,
+    val event: String? = null,
+    val data: String,
+    val retry: Long? = null,
+    val timestamp: Long = System.currentTimeMillis(),
+)
+
+/**
+ * Network capture options for automatic client integrations.
+ */
+data class NetworkCaptureConfig(
+    val maxBodyBytes: Long = 256L * 1024L,
+    val maxSSEEvents: Int = 200,
+    val redactedHeaders: Set<String> = CapturedRequest.defaultSensitiveHeaders,
+    val captureBodies: Boolean = true,
+)
+
+/**
+ * Captured network request data. Matches iOS CapturedRequest shape.
  */
 data class CapturedRequest(
     val id: String =
@@ -18,11 +39,17 @@ data class CapturedRequest(
     val responseHeaders: Map<String, String>? = null,
     val requestBodySize: Int? = null,
     val responseBodySize: Int? = null,
+    val requestBody: String? = null,
+    val responseBody: String? = null,
+    val requestBodyTruncated: Boolean = false,
+    val responseBodyTruncated: Boolean = false,
+    val sseEvents: List<CapturedSSEEvent> = emptyList(),
+    val isStreaming: Boolean = false,
     val error: String? = null,
     val redirectCount: Int = 0,
 ) {
     companion object {
-        private val sensitiveHeaders =
+        val defaultSensitiveHeaders =
             setOf(
                 "authorization",
                 "cookie",
@@ -32,14 +59,27 @@ data class CapturedRequest(
                 "proxy-authorization",
             )
 
-        fun redactSensitiveHeaders(headers: Map<String, String>): Map<String, String> =
+        fun redactSensitiveHeaders(
+            headers: Map<String, String>,
+            redactedHeaders: Set<String> = defaultSensitiveHeaders,
+        ): Map<String, String> =
             headers.mapValues { (key, value) ->
-                if (sensitiveHeaders.contains(key.lowercase())) "[REDACTED]" else value
+                redactHeader(key, value, redactedHeaders)
             }
+
+        fun redactHeader(
+            key: String,
+            value: String,
+            redactedHeaders: Set<String> = defaultSensitiveHeaders,
+        ): String = if (redactedHeaders.contains(key.lowercase())) "[REDACTED]" else value
     }
 
     /**
-     * Returns a copy with sensitive request headers redacted.
+     * Returns a copy with sensitive headers redacted.
      */
-    fun withRedactedHeaders(): CapturedRequest = copy(requestHeaders = redactSensitiveHeaders(requestHeaders))
+    fun withRedactedHeaders(redactedHeaders: Set<String> = defaultSensitiveHeaders): CapturedRequest =
+        copy(
+            requestHeaders = redactSensitiveHeaders(requestHeaders, redactedHeaders),
+            responseHeaders = responseHeaders?.let { redactSensitiveHeaders(it, redactedHeaders) },
+        )
 }

--- a/Android/appreveal/src/main/kotlin/com/appreveal/network/NetworkObserver.kt
+++ b/Android/appreveal/src/main/kotlin/com/appreveal/network/NetworkObserver.kt
@@ -21,7 +21,7 @@ interface NetworkTrafficObserver {
  */
 internal object NetworkObserverService : NetworkTrafficObserver {
     private const val MAX_BUFFER_SIZE = 200
-    private val capturedRequests = mutableListOf<CapturedRequest>()
+    private val capturedRequests = LinkedHashMap<String, CapturedRequest>()
     private var observable: NetworkObservable? = null
 
     @Synchronized
@@ -33,24 +33,43 @@ internal object NetworkObserverService : NetworkTrafficObserver {
 
     @Synchronized
     override fun didCapture(request: CapturedRequest) {
-        capturedRequests.add(request.withRedactedHeaders())
-        if (capturedRequests.size > MAX_BUFFER_SIZE) {
-            capturedRequests.removeAt(0)
-        }
+        addOrUpdate(request.withRedactedHeaders())
+    }
+
+    @Synchronized
+    fun addCall(request: CapturedRequest) {
+        addOrUpdate(request.withRedactedHeaders())
+    }
+
+    @Synchronized
+    fun updateCall(
+        id: String,
+        transform: (CapturedRequest) -> CapturedRequest,
+    ) {
+        val existing = capturedRequests[id] ?: return
+        addOrUpdate(transform(existing).withRedactedHeaders())
     }
 
     @Synchronized
     fun recentCalls(limit: Int = 50): List<CapturedRequest> {
         val size = capturedRequests.size
         val fromIndex = maxOf(0, size - limit)
-        return capturedRequests.subList(fromIndex, size).toList()
+        return capturedRequests.values.toList().subList(fromIndex, size).toList()
     }
 
     @Synchronized
-    fun callDetail(id: String): CapturedRequest? = capturedRequests.firstOrNull { it.id == id }
+    fun callDetail(id: String): CapturedRequest? = capturedRequests[id]
 
     @Synchronized
     fun clear() {
         capturedRequests.clear()
+    }
+
+    private fun addOrUpdate(request: CapturedRequest) {
+        capturedRequests[request.id] = request
+        while (capturedRequests.size > MAX_BUFFER_SIZE) {
+            val oldest = capturedRequests.keys.firstOrNull() ?: return
+            capturedRequests.remove(oldest)
+        }
     }
 }

--- a/Android/appreveal/src/test/kotlin/com/appreveal/mcpserver/MCPRouterTest.kt
+++ b/Android/appreveal/src/test/kotlin/com/appreveal/mcpserver/MCPRouterTest.kt
@@ -1,5 +1,8 @@
 package com.appreveal.mcpserver
 
+import com.appreveal.network.CapturedRequest
+import com.appreveal.network.CapturedSSEEvent
+import com.appreveal.network.NetworkObserverService
 import com.google.gson.JsonArray
 import com.google.gson.JsonObject
 import org.junit.After
@@ -13,11 +16,13 @@ class MCPRouterTest {
     @Before
     fun setUp() {
         MCPRouter.clearAll()
+        NetworkObserverService.clear()
     }
 
     @After
     fun tearDown() {
         MCPRouter.clearAll()
+        NetworkObserverService.clear()
     }
 
     @Test
@@ -99,6 +104,48 @@ class MCPRouterTest {
             "screenshot must be called directly to return MCP image content",
             batchResult.getAsJsonArray("results")[0].asJsonObject.get("error").asString,
         )
+    }
+
+    @Test
+    fun `network call detail exposes headers bodies and sse frames`() {
+        registerBuiltInTools()
+        NetworkObserverService.addCall(
+            CapturedRequest(
+                id = "call-1",
+                method = "GET",
+                url = "https://api.example.com/converse/stream",
+                statusCode = 200,
+                requestHeaders = mapOf("Authorization" to "Bearer secret"),
+                responseHeaders = mapOf("Content-Type" to "text/event-stream", "Set-Cookie" to "session=secret"),
+                responseBody = "data: hello\n\n",
+                responseBodySize = 13,
+                sseEvents = listOf(CapturedSSEEvent(event = "message", data = "hello")),
+                isStreaming = true,
+            ),
+        )
+
+        val summary = callTool("get_network_calls")
+        val summaryText = summary.getAsJsonArray("content")[0].asJsonObject.get("text").asString
+        val summaryJson = MCPGson.gson.fromJson(summaryText, JsonObject::class.java)
+        val listedCall = summaryJson.getAsJsonArray("calls")[0].asJsonObject
+        assertEquals("call-1", listedCall.get("id").asString)
+        assertEquals(1, listedCall.get("sseEventCount").asInt)
+
+        val detailArgs = JsonObject().apply { addProperty("id", "call-1") }
+        val detail = callTool("get_network_call_detail", detailArgs)
+        val detailText = detail.getAsJsonArray("content")[0].asJsonObject.get("text").asString
+        val detailJson = MCPGson.gson.fromJson(detailText, JsonObject::class.java)
+
+        assertEquals(
+            "[REDACTED]",
+            detailJson.getAsJsonObject("request").getAsJsonObject("headers").get("Authorization").asString,
+        )
+        assertEquals(
+            "[REDACTED]",
+            detailJson.getAsJsonObject("response").getAsJsonObject("headers").get("Set-Cookie").asString,
+        )
+        assertEquals("data: hello\n\n", detailJson.getAsJsonObject("response").get("body").asString)
+        assertEquals("hello", detailJson.getAsJsonArray("sseEvents")[0].asJsonObject.get("data").asString)
     }
 
     private fun registerTool(

--- a/Android/appreveal/src/test/kotlin/com/appreveal/network/OkHttpCaptureTest.kt
+++ b/Android/appreveal/src/test/kotlin/com/appreveal/network/OkHttpCaptureTest.kt
@@ -1,0 +1,95 @@
+package com.appreveal.network
+
+import com.appreveal.AppRevealOkHttp
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.mockwebserver.MockResponse
+import okhttp3.mockwebserver.MockWebServer
+import org.junit.After
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class OkHttpCaptureTest {
+    private lateinit var server: MockWebServer
+
+    @Before
+    fun setUp() {
+        NetworkObserverService.clear()
+        server = MockWebServer()
+        server.start()
+    }
+
+    @After
+    fun tearDown() {
+        server.shutdown()
+        NetworkObserverService.clear()
+    }
+
+    @Test
+    fun `okhttp interceptor captures request and response details`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setHeader("Set-Cookie", "session=secret")
+                .setBody("""{"updated_at":"2026-07-14T21:36:14Z"}"""),
+        )
+        val client =
+            OkHttpClient.Builder()
+                .addInterceptor(AppRevealOkHttp.interceptor(NetworkCaptureConfig(maxBodyBytes = 1024)))
+                .build()
+        val request =
+            Request.Builder()
+                .url(server.url("/converse/session/abc"))
+                .header("Authorization", "Bearer secret")
+                .post("""{"resume":true}""".toRequestBody("application/json".toMediaType()))
+                .build()
+
+        client.newCall(request).execute().use { response ->
+            assertEquals("""{"updated_at":"2026-07-14T21:36:14Z"}""", response.body!!.string())
+        }
+
+        val call = NetworkObserverService.recentCalls(limit = 10).single()
+        assertEquals("POST", call.method)
+        assertTrue(call.url.endsWith("/converse/session/abc"))
+        assertEquals(200, call.statusCode)
+        assertEquals("[REDACTED]", call.requestHeaders["Authorization"])
+        assertEquals("[REDACTED]", call.responseHeaders?.get("Set-Cookie"))
+        assertEquals("""{"resume":true}""", call.requestBody)
+        assertEquals("""{"updated_at":"2026-07-14T21:36:14Z"}""", call.responseBody)
+        assertNotNull(call.endTime)
+        assertTrue((call.responseBodySize ?: 0) > 0)
+    }
+
+    @Test
+    fun `okhttp interceptor captures server sent event frames`() {
+        server.enqueue(
+            MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "text/event-stream")
+                .setBody("id: 1\nevent: token\ndata: hello\n\ndata: world\n\n"),
+        )
+        val client =
+            OkHttpClient.Builder()
+                .addInterceptor(AppRevealOkHttp.interceptor(NetworkCaptureConfig(maxBodyBytes = 1024)))
+                .build()
+        val request = Request.Builder().url(server.url("/converse/stream")).build()
+
+        client.newCall(request).execute().use { response ->
+            assertTrue(response.body!!.string().contains("hello"))
+        }
+
+        val call = NetworkObserverService.recentCalls(limit = 10).single()
+        assertTrue(call.isStreaming)
+        assertTrue(call.responseBody?.contains("data: hello") == true)
+        assertEquals(2, call.sseEvents.size)
+        assertEquals("token", call.sseEvents[0].event)
+        assertEquals("hello", call.sseEvents[0].data)
+        assertEquals("world", call.sseEvents[1].data)
+    }
+}

--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ All native UI tools and all web view tools accept an optional `window_id` parame
 | `get_navigation_stack` | Current route, nav stack, modal stack |
 | `get_feature_flags` | All active feature flags |
 | `get_network_calls` | Recent HTTP traffic with method, URL, status, duration |
+| `get_network_call_detail` | Captured request/response headers, bodies, and SSE frames where supported |
 | `get_logs` | Recent app logs |
 | `get_recent_errors` | Recent captured errors when an error-capture provider is available |
 | `launch_context` | App ID, version, device model, OS version |

--- a/docs/android.md
+++ b/docs/android.md
@@ -181,6 +181,38 @@ interface NetworkObservable {
 }
 ```
 
+### OkHttp request/response capture
+
+Android apps that use OkHttp can capture real HTTP traffic, including response bodies and
+`text/event-stream` / Server-Sent Event frames, by installing the debug interceptor on the
+app's OkHttp client:
+
+```kotlin
+val client = AppRevealOkHttp.install(OkHttpClient.Builder()).build()
+```
+
+For explicit limits or extra header redaction:
+
+```kotlin
+val client = AppRevealOkHttp.install(
+    OkHttpClient.Builder(),
+    NetworkCaptureConfig(
+        maxBodyBytes = 64L * 1024L,
+        redactedHeaders = CapturedRequest.defaultSensitiveHeaders + "x-session-token",
+    ),
+).build()
+```
+
+`get_network_calls` lists captured calls; `get_network_call_detail` returns one call's request
+and response headers, captured text bodies, truncation flags, and parsed SSE frames. Release
+builds use the `appreveal-noop` helper, so shared debug/release networking setup can keep the
+same calls while the release interceptor simply passes through.
+
+Parity note: Android has OkHttp body/SSE detail capture. iOS exposes the same
+`get_network_call_detail` tool and captures URLSession text body previews; app-fed integrations
+can also provide body fields. macOS/Flutter/React Native keep their existing app-fed or fetch
+summary capture until matching automatic body-detail hooks are implemented there.
+
 ## Security
 
 - Library added as `debugImplementation` -- not included in release APK
@@ -188,7 +220,7 @@ interface NetworkObservable {
 - Health diagnostics available at `GET /health`
 - Loopback CORS only
 - NsdManager advertises `_appreveal._tcp` with `auth=session-token`
-- Sensitive headers (Authorization, Cookie) redacted in network capture
+- Sensitive headers (Authorization, Cookie, Set-Cookie, x-api-key, x-auth-token) redacted in network capture
 
 ## Platform details
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -241,7 +241,7 @@ protocol FeatureFlagProviding {
 | `launch_context` | App launch environment info |
 | `open_deeplink` | Navigate via deep link URL |
 
-Network call detail, network mocking, MetricKit summaries, and reset-state commands are planned extension tools. They are not part of the current cross-platform parity set until every target can advertise and implement them consistently.
+Android OkHttp builds expose `get_network_call_detail` for captured request/response headers, text bodies, and SSE frames. iOS URLSession capture uses the same tool for text body previews. Network mocking, MetricKit summaries, reset-state commands, and matching automatic body-detail capture for the remaining platforms are planned extension work.
 
 All UI and WKWebView tools accept an optional `window_id` parameter from `list_windows`. If omitted, AppReveal targets the current key window.
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -331,6 +331,41 @@ Sensitive headers (`Authorization`, `Cookie`, `Set-Cookie`, `x-api-key`, `x-auth
 
 ---
 
+### `get_network_call_detail`
+One captured HTTP call with request/response headers, captured text bodies, truncation flags, and parsed Server-Sent Event frames where available.
+
+**Parameters:**
+- `id` (string, required) — call id returned by `get_network_calls`
+
+**Response:**
+```json
+{
+  "id": "abc123",
+  "method": "GET",
+  "url": "https://api.example.com/converse/session/123",
+  "statusCode": 200,
+  "request": {
+    "headers": { "Authorization": "[REDACTED]" },
+    "body": null,
+    "bodySize": null,
+    "bodyTruncated": false
+  },
+  "response": {
+    "headers": { "Content-Type": "text/event-stream" },
+    "body": "data: hello\n\n",
+    "bodySize": 13,
+    "bodyTruncated": false
+  },
+  "sseEvents": [
+    { "event": "message", "data": "hello" }
+  ]
+}
+```
+
+Platform note: Android's OkHttp integration captures request/response bodies and parsed SSE frames. iOS URLSession capture records text body previews and exposes the same detail tool; other platforms currently expose their existing network summaries unless the app-fed integration provides body fields.
+
+---
+
 ### `get_logs`
 Recent app log output.
 

--- a/example/Android/app/build.gradle.kts
+++ b/example/Android/app/build.gradle.kts
@@ -43,5 +43,6 @@ dependencies {
     implementation("androidx.compose.ui:ui:1.6.1")
     implementation("androidx.compose.ui:ui-tooling-preview:1.6.1")
     implementation("androidx.compose.material3:material3:1.2.0")
+    implementation("com.squareup.okhttp3:okhttp:4.12.0")
     debugImplementation("androidx.compose.ui:ui-tooling:1.6.1")
 }

--- a/example/Android/app/src/main/kotlin/com/appreveal/example/services/ExampleNetworkClient.kt
+++ b/example/Android/app/src/main/kotlin/com/appreveal/example/services/ExampleNetworkClient.kt
@@ -2,16 +2,46 @@ package com.appreveal.example.services
 
 import android.os.Handler
 import android.os.Looper
+import com.appreveal.AppRevealOkHttp
 import com.appreveal.example.models.ExampleOrder
 import com.appreveal.example.models.ExampleProduct
 import com.appreveal.network.CapturedRequest
+import com.appreveal.network.NetworkCaptureConfig
 import com.appreveal.network.NetworkObservable
 import com.appreveal.network.NetworkTrafficObserver
+import okhttp3.Callback
+import okhttp3.Call
+import okhttp3.MediaType.Companion.toMediaType
+import okhttp3.OkHttpClient
+import okhttp3.Protocol
+import okhttp3.Request
+import okhttp3.RequestBody.Companion.toRequestBody
+import okhttp3.Response
+import okhttp3.ResponseBody.Companion.toResponseBody
+import java.io.IOException
 
 object ExampleNetworkClient : NetworkObservable {
 
     private val handler = Handler(Looper.getMainLooper())
     private val observers = mutableListOf<NetworkTrafficObserver>()
+    private val jsonMediaType = "application/json".toMediaType()
+    private val client =
+        AppRevealOkHttp
+            .install(
+                OkHttpClient.Builder(),
+                NetworkCaptureConfig(maxBodyBytes = 64L * 1024L),
+            ).addInterceptor { chain ->
+                val request = chain.request()
+                Response
+                    .Builder()
+                    .request(request)
+                    .protocol(Protocol.HTTP_1_1)
+                    .code(200)
+                    .message("OK")
+                    .header("Content-Type", "application/json")
+                    .body(fakeResponseBody(request.url.encodedPath).toResponseBody(jsonMediaType))
+                    .build()
+            }.build()
 
     override val recentRequests: List<CapturedRequest> = emptyList()
 
@@ -20,7 +50,7 @@ object ExampleNetworkClient : NetworkObservable {
     }
 
     fun login(email: String, password: String, callback: (Result<Unit>) -> Unit) {
-        simulateRequest("POST", "/api/auth/login") {
+        simulateRequest("POST", "/api/auth/login", """{"email":"$email","password":"$password"}""") {
             if (email.contains("@") && password.isNotEmpty()) {
                 callback(Result.success(Unit))
             } else {
@@ -58,31 +88,49 @@ object ExampleNetworkClient : NetworkObservable {
     private fun simulateRequest(
         method: String,
         path: String,
+        requestJson: String? = null,
         delayMs: Long = 300,
         work: () -> Unit
     ) {
         val url = "https://api.example.com$path"
-        val startTime = System.currentTimeMillis()
-
         handler.postDelayed({
-            val captured = CapturedRequest(
-                method = method,
-                url = url,
-                statusCode = 200,
-                startTime = startTime,
-                endTime = System.currentTimeMillis(),
-                duration = delayMs.toDouble() / 1000.0,
-                requestHeaders = mapOf(
-                    "Content-Type" to "application/json",
-                    "Authorization" to "Bearer token123"
-                ),
-                responseHeaders = mapOf("Content-Type" to "application/json"),
-                requestBodySize = if (method == "POST") 128 else null,
-                responseBodySize = 2048,
-                redirectCount = 0
+            val body = requestJson?.toRequestBody(jsonMediaType)
+            val request =
+                Request
+                    .Builder()
+                    .url(url)
+                    .header("Accept", "application/json")
+                    .header("Authorization", "Bearer token123")
+                    .method(method, body)
+                    .build()
+            client.newCall(request).enqueue(
+                object : Callback {
+                    override fun onFailure(
+                        call: Call,
+                        e: IOException,
+                    ) {
+                        handler.post(work)
+                    }
+
+                    override fun onResponse(
+                        call: Call,
+                        response: Response,
+                    ) {
+                        response.use { it.body?.string() }
+                        handler.post(work)
+                    }
+                },
             )
-            observers.forEach { it.didCapture(captured) }
-            work()
         }, delayMs)
     }
+
+    private fun fakeResponseBody(path: String): String =
+        when {
+            path.endsWith("/auth/login") -> """{"ok":true,"token":"debug-token"}"""
+            path.endsWith("/orders") -> """{"items":${ExampleOrder.samples.size}}"""
+            path.contains("/orders/") -> """{"id":"${path.substringAfterLast("/")}"}"""
+            path.endsWith("/products") -> """{"items":${ExampleProduct.samples.size}}"""
+            path.endsWith("/profile") -> """{"name":"Test User","email":"test@example.com"}"""
+            else -> """{"ok":true}"""
+        }
 }

--- a/iOS/Sources/AppReveal/MCPServer/MCPTools.swift
+++ b/iOS/Sources/AppReveal/MCPServer/MCPTools.swift
@@ -70,7 +70,7 @@ func registerBuiltInTools() {
 
     router.register(MCPToolDefinition(
         name: "get_network_calls",
-        description: "Get recent network calls",
+        description: "List recent network calls captured by AppReveal",
         inputSchema: [
             "type": AnyCodable("object"),
             "properties": AnyCodable(["limit": ["type": "integer", "description": "Max results (default 50)"]] as [String: Any])
@@ -78,17 +78,29 @@ func registerBuiltInTools() {
         handler: { params in
             let limit = params?["limit"]?.intValue ?? 50
             let calls = NetworkObserverService.shared.recentCalls(limit: limit)
-            let list = calls.map { call in
-                [
-                    "id": call.id,
-                    "method": call.method,
-                    "url": call.url,
-                    "statusCode": call.statusCode.map { String($0) } ?? "nil",
-                    "duration": call.duration.map { String(format: "%.3fs", $0) } ?? "nil",
-                    "error": call.error ?? ""
-                ]
-            }
+            let list = calls.map { $0.networkSummary }
             return AnyCodable(["calls": list, "count": list.count] as [String: Any])
+        }
+    ))
+
+    // MARK: - get_network_call_detail (cross-platform)
+
+    router.register(MCPToolDefinition(
+        name: "get_network_call_detail",
+        description: "Get headers, body previews, and SSE frames for one captured network call",
+        inputSchema: [
+            "type": AnyCodable("object"),
+            "properties": AnyCodable(["id": ["type": "string", "description": "Network call id from get_network_calls"]] as [String: Any]),
+            "required": AnyCodable(["id"])
+        ],
+        handler: { params in
+            guard let id = params?["id"]?.stringValue else {
+                return AnyCodable(["error": "id required"])
+            }
+            guard let call = NetworkObserverService.shared.callDetail(id: id) else {
+                return AnyCodable(["error": "Network call not found: \(id)"])
+            }
+            return AnyCodable(call.networkDetail)
         }
     ))
 
@@ -456,6 +468,64 @@ func registerBuiltInTools() {
     #elseif os(macOS)
     registerMacOSBuiltInTools()
     #endif
+}
+
+private extension CapturedRequest {
+    var networkSummary: [String: Any] {
+        [
+            "id": id,
+            "method": method,
+            "url": url,
+            "statusCode": jsonNullable(statusCode),
+            "startTime": Int(startTime.timeIntervalSince1970 * 1000),
+            "endTime": jsonNullable(endTime.map { Int($0.timeIntervalSince1970 * 1000) }),
+            "durationMs": jsonNullable(duration.map { Int($0 * 1000) }),
+            "duration": duration.map { String(format: "%.3fs", $0) } ?? "nil",
+            "requestBodySize": jsonNullable(requestBodySize),
+            "responseBodySize": jsonNullable(responseBodySize),
+            "requestBodyTruncated": requestBodyTruncated,
+            "responseBodyTruncated": responseBodyTruncated,
+            "isStreaming": isStreaming,
+            "sseEventCount": sseEvents.count,
+            "complete": endTime != nil,
+            "error": error ?? ""
+        ]
+    }
+
+    var networkDetail: [String: Any] {
+        var detail = networkSummary
+        detail["redirectCount"] = redirectCount
+        detail["request"] = [
+            "headers": requestHeaders,
+            "body": jsonNullable(requestBody),
+            "bodySize": jsonNullable(requestBodySize),
+            "bodyTruncated": requestBodyTruncated
+        ] as [String: Any]
+        detail["response"] = [
+            "headers": responseHeaders ?? [:],
+            "body": jsonNullable(responseBody),
+            "bodySize": jsonNullable(responseBodySize),
+            "bodyTruncated": responseBodyTruncated
+        ] as [String: Any]
+        detail["sseEvents"] = sseEvents.map { $0.dictionaryValue }
+        return detail
+    }
+}
+
+private extension CapturedSSEEvent {
+    var dictionaryValue: [String: Any] {
+        [
+            "id": jsonNullable(id),
+            "event": jsonNullable(event),
+            "data": data,
+            "retry": jsonNullable(retry),
+            "timestamp": Int(timestamp.timeIntervalSince1970 * 1000)
+        ]
+    }
+}
+
+private func jsonNullable<T>(_ value: T?) -> Any {
+    value.map { $0 as Any } ?? NSNull()
 }
 
 // MARK: - iOS-specific tools

--- a/iOS/Sources/AppReveal/Network/CapturedRequest.swift
+++ b/iOS/Sources/AppReveal/Network/CapturedRequest.swift
@@ -4,6 +4,28 @@ import Foundation
 
 #if DEBUG
 
+public struct CapturedSSEEvent: Codable {
+    public let id: String?
+    public let event: String?
+    public let data: String
+    public let retry: Int?
+    public let timestamp: Date
+
+    public init(
+        id: String? = nil,
+        event: String? = nil,
+        data: String,
+        retry: Int? = nil,
+        timestamp: Date = Date()
+    ) {
+        self.id = id
+        self.event = event
+        self.data = data
+        self.retry = retry
+        self.timestamp = timestamp
+    }
+}
+
 public struct CapturedRequest: Codable {
     public let id: String
     public let method: String
@@ -16,6 +38,12 @@ public struct CapturedRequest: Codable {
     public let responseHeaders: [String: String]?
     public let requestBodySize: Int?
     public let responseBodySize: Int?
+    public let requestBody: String?
+    public let responseBody: String?
+    public let requestBodyTruncated: Bool
+    public let responseBodyTruncated: Bool
+    public let sseEvents: [CapturedSSEEvent]
+    public let isStreaming: Bool
     public let error: String?
     public let redirectCount: Int
 
@@ -31,6 +59,12 @@ public struct CapturedRequest: Codable {
         responseHeaders: [String: String]? = nil,
         requestBodySize: Int? = nil,
         responseBodySize: Int? = nil,
+        requestBody: String? = nil,
+        responseBody: String? = nil,
+        requestBodyTruncated: Bool = false,
+        responseBodyTruncated: Bool = false,
+        sseEvents: [CapturedSSEEvent] = [],
+        isStreaming: Bool = false,
         error: String? = nil,
         redirectCount: Int = 0
     ) {
@@ -42,9 +76,15 @@ public struct CapturedRequest: Codable {
         self.endTime = endTime
         self.duration = duration
         self.requestHeaders = CapturedRequest.redactSensitiveHeaders(requestHeaders)
-        self.responseHeaders = responseHeaders
+        self.responseHeaders = responseHeaders.map(CapturedRequest.redactSensitiveHeaders)
         self.requestBodySize = requestBodySize
         self.responseBodySize = responseBodySize
+        self.requestBody = requestBody
+        self.responseBody = responseBody
+        self.requestBodyTruncated = requestBodyTruncated
+        self.responseBodyTruncated = responseBodyTruncated
+        self.sseEvents = sseEvents
+        self.isStreaming = isStreaming
         self.error = error
         self.redirectCount = redirectCount
     }

--- a/iOS/Sources/AppReveal/Network/URLSessionCapture.swift
+++ b/iOS/Sources/AppReveal/Network/URLSessionCapture.swift
@@ -22,12 +22,15 @@ final class URLSessionCapture {
 private final class AppRevealCaptureProtocol: URLProtocol, URLSessionDataDelegate {
 
     private static let handledKey = "AppRevealCaptureHandled"
+    private static let maxBodyBytes = 256 * 1024
 
     private var session: URLSession?
     private var dataTask: URLSessionDataTask?
     private var startTime = Date()
     private var response: HTTPURLResponse?
     private var responseBodySize = 0
+    private var responseBody = Data()
+    private var responseBodyTruncated = false
     private var redirectCount = 0
 
     override static func canInit(with request: URLRequest) -> Bool {
@@ -78,6 +81,15 @@ private final class AppRevealCaptureProtocol: URLProtocol, URLSessionDataDelegat
         let responseHeaders = response?.allHeaderFields.reduce(into: [String: String]()) { partial, item in
             partial[String(describing: item.key)] = String(describing: item.value)
         }
+        let requestContentType = request.value(forHTTPHeaderField: "Content-Type")
+        let responseContentType = response?.value(forHTTPHeaderField: "Content-Type")
+        let requestBody = request.httpBody.flatMap { body in
+            Self.isTextLike(requestContentType) ? String(data: body, encoding: .utf8) : nil
+        }
+        let responseBodyPreview =
+            Self.isTextLike(responseContentType)
+                ? String(data: responseBody, encoding: .utf8)
+                : nil
 
         let captured = CapturedRequest(
             method: request.httpMethod ?? "GET",
@@ -90,6 +102,11 @@ private final class AppRevealCaptureProtocol: URLProtocol, URLSessionDataDelegat
             responseHeaders: responseHeaders,
             requestBodySize: request.httpBody?.count,
             responseBodySize: responseBodySize,
+            requestBody: requestBody,
+            responseBody: responseBodyPreview,
+            requestBodyTruncated: false,
+            responseBodyTruncated: responseBodyTruncated,
+            isStreaming: Self.isEventStream(responseContentType),
             error: error?.localizedDescription,
             redirectCount: redirectCount
         )
@@ -101,6 +118,13 @@ private final class AppRevealCaptureProtocol: URLProtocol, URLSessionDataDelegat
 
     func urlSession(_ session: URLSession, dataTask: URLSessionDataTask, didReceive data: Data) {
         responseBodySize += data.count
+        let remaining = Self.maxBodyBytes - responseBody.count
+        if remaining > 0 {
+            responseBody.append(contentsOf: data.prefix(remaining))
+        }
+        if data.count > max(remaining, 0) {
+            responseBodyTruncated = true
+        }
         client?.urlProtocol(self, didLoad: data)
     }
 
@@ -136,6 +160,20 @@ private final class AppRevealCaptureProtocol: URLProtocol, URLSessionDataDelegat
 
         captureCompletedRequest(error: error)
         session.finishTasksAndInvalidate()
+    }
+
+    private static func isTextLike(_ contentType: String?) -> Bool {
+        guard let contentType = contentType?.lowercased() else { return false }
+        return contentType.hasPrefix("text/")
+            || contentType.contains("json")
+            || contentType.contains("xml")
+            || contentType.contains("x-www-form-urlencoded")
+            || contentType.contains("graphql")
+            || contentType.contains("event-stream")
+    }
+
+    private static func isEventStream(_ contentType: String?) -> Bool {
+        contentType?.lowercased().contains("text/event-stream") == true
     }
 }
 

--- a/iOS/Tests/AppRevealTests/CapturedRequestTests.swift
+++ b/iOS/Tests/AppRevealTests/CapturedRequestTests.swift
@@ -17,6 +17,20 @@ final class CapturedRequestTests: XCTestCase {
         XCTAssertEqual(request.requestHeaders["Authorization"], "[REDACTED]")
         XCTAssertEqual(request.requestHeaders["X-Trace-Id"], "trace-123")
     }
+
+    func testResponseHeadersAreRedactedIndividually() {
+        let request = CapturedRequest(
+            method: "GET",
+            url: "https://example.com",
+            responseHeaders: [
+                "Set-Cookie": "secret",
+                "X-Trace-Id": "trace-123"
+            ]
+        )
+
+        XCTAssertEqual(request.responseHeaders?["Set-Cookie"], "[REDACTED]")
+        XCTAssertEqual(request.responseHeaders?["X-Trace-Id"], "trace-123")
+    }
 }
 
 #endif

--- a/iOS/Tests/AppRevealTests/MCPRouterTests.swift
+++ b/iOS/Tests/AppRevealTests/MCPRouterTests.swift
@@ -5,6 +5,10 @@ import XCTest
 
 @MainActor
 final class MCPRouterTests: XCTestCase {
+    override func tearDown() {
+        NetworkObserverService.shared.clear()
+        super.tearDown()
+    }
 
     func testImageToolReturnsMCPImageBlockAndMetadata() async throws {
         let imageData = "iVBORw0KGgoAAAANSUhEUgAAAAEAAAAB"
@@ -121,6 +125,37 @@ final class MCPRouterTests: XCTestCase {
         XCTAssertNil(result["structuredContent"])
     }
 
+    func testNetworkCallDetailExposesHeadersBodiesAndSSEFrames() async throws {
+        registerBuiltInTools()
+        NetworkObserverService.shared.addCall(CapturedRequest(
+            id: "call-1",
+            method: "GET",
+            url: "https://api.example.com/converse/stream",
+            statusCode: 200,
+            responseHeaders: ["Content-Type": "text/event-stream"],
+            responseBodySize: 13,
+            responseBody: "data: hello\n\n",
+            sseEvents: [CapturedSSEEvent(event: "message", data: "hello")],
+            isStreaming: true
+        ))
+
+        let response = await MCPRouter.shared.handle(toolRequest(
+            name: "get_network_call_detail",
+            arguments: ["id": "call-1"]
+        ))
+        let result = try resultObject(from: response)
+        let content = try XCTUnwrap(result["content"] as? [[String: Any]])
+        let text = try XCTUnwrap(content[0]["text"] as? String)
+        let data = try XCTUnwrap(text.data(using: .utf8))
+        let detail = try XCTUnwrap(JSONSerialization.jsonObject(with: data) as? [String: Any])
+
+        let responseDetail = try XCTUnwrap(detail["response"] as? [String: Any])
+        XCTAssertEqual(responseDetail["body"] as? String, "data: hello\n\n")
+        let sseEvents = try XCTUnwrap(detail["sseEvents"] as? [[String: Any]])
+        XCTAssertEqual(sseEvents.first?["data"] as? String, "hello")
+        XCTAssertEqual(detail["sseEventCount"] as? Int, 1)
+    }
+
     private var emptySchema: [String: AnyCodable] {
         [
             "type": AnyCodable("object"),
@@ -128,14 +163,17 @@ final class MCPRouterTests: XCTestCase {
         ]
     }
 
-    private func toolRequest(name: String) -> MCPRequest {
+    private func toolRequest(
+        name: String,
+        arguments: [String: Any] = [:]
+    ) -> MCPRequest {
         MCPRequest(
             jsonrpc: "2.0",
             id: .int(1),
             method: "tools/call",
             params: [
                 "name": AnyCodable(name),
-                "arguments": AnyCodable([String: Any]())
+                "arguments": AnyCodable(arguments)
             ]
         )
     }


### PR DESCRIPTION
Closes #52

## What changed
- Added `AppRevealOkHttp` for Android OkHttp clients, with request/response header capture, bounded text body capture, redaction, streaming updates, and parsed SSE frames.
- Added `get_network_call_detail` alongside richer `get_network_calls` summaries.
- Added release no-op OkHttp stubs so shared debug/release client setup compiles cleanly.
- Added matching iOS network detail shape and URLSession text body previews for tool-surface parity.
- Updated the Android example to exercise the OkHttp capture path and documented the integration/parity notes.

## Verification
- Android unit tests: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="/Users/dictator/Library/Android/sdk" ./gradlew :appreveal:testDebugUnitTest --rerun-tasks`
- Android ktlint: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="/Users/dictator/Library/Android/sdk" ./gradlew :appreveal:ktlintCheck :appreveal-noop:ktlintCheck`
- Android no-op compile: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="/Users/dictator/Library/Android/sdk" ./gradlew :appreveal-noop:assembleDebug --rerun-tasks`
- Android example build: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="/Users/dictator/Library/Android/sdk" ./gradlew :app:assembleDebug`
- Android Emulator MCP: installed the example on `emulator-5554`, drove login through AppReveal MCP, and verified `get_network_calls` plus `get_network_call_detail` returned the OkHttp POST body, response body, and redacted `Authorization` header.
- Android Emulator regression: `JAVA_HOME="/Applications/Android Studio.app/Contents/jbr/Contents/Home" ANDROID_HOME="/Users/dictator/Library/Android/sdk" ANDROID_SERIAL="emulator-5554" ./verify-compose-mcp.sh`
- iOS Simulator smoke: XcodeBuildMCP `build_run_sim` for `AppRevealExample` on iPhone 17 Pro Max, followed by live MCP `get_network_calls`.
- iOS unit tests: `swift test` in `iOS/`.
