### PR TITLE
Fix iOS SwiftUI identifier-only tap fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,8 @@ AppReveal.start()
 
 `tap_point` and `tap_element` on SwiftUI views require private UIKit APIs on iOS 26+. AppReveal compiles this code in automatically for **debug builds** and compiles it **out for release builds** — no private symbols reach your App Store binary. No setup needed.
 
+When SwiftUI renders visible text without exposing accessibility nodes, AppReveal falls back to iOS Vision text recognition inside SwiftUI hosting views. Those entries appear with `idSource: "ocr"` and work with `tap_text`; `tap_element` can also fall back from identifiers like `device.chip.mouser` to visible text such as `mouser`.
+
 To opt out of private APIs entirely (even in debug builds), remove the `swiftSettings` line from AppReveal's `Package.swift`. See [iOS guide](docs/ios.md) for details.
 
 ### macOS

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -83,13 +83,13 @@ Enumerates visible interactive elements. Each element exposes:
 - `enabled`, `visible`, `tappable`
 - `frame` (CGRect in screen coordinates)
 - `actions` (available interaction types)
-- `idSource` — how the ID was derived: `"explicit"`, `"appReveal"`, `"text"`, `"semantics"`, `"tooltip"`, `"derived"`
+- `idSource` — how the ID was derived: `"explicit"`, `"appReveal"`, `"ocr"`, `"text"`, `"semantics"`, `"tooltip"`, `"derived"`
 
 ID resolution cascade: explicit accessibility identifier → semantics (accessibility label / content description) → visible text (normalized to snake_case) → auto-generated derived ID. Duplicate IDs are disambiguated with `_1`, `_2`, etc.
 
-Text-based element lookup via `tap_text` walks the view hierarchy for matching visible text, then resolves the nearest tappable ancestor (UIControl, NSControl, gesture-recognizer-bearing view, table/collection cell).
+Text-based element lookup via `tap_text` walks the view hierarchy for matching visible text, then resolves the nearest tappable ancestor (UIControl, NSControl, gesture-recognizer-bearing view, table/collection cell). On iOS it can also target Vision-recognized text inside SwiftUI hosting views when SwiftUI does not expose native accessibility nodes.
 
-Walks the UIKit or AppKit view hierarchy for the selected window. SwiftUI elements are accessed through their hosting layer and accessibility identifiers.
+Walks the UIKit or AppKit view hierarchy for the selected window. SwiftUI elements are accessed through their hosting layer, accessibility/automation elements, `.appReveal(...)` registration, and iOS OCR fallback for visible text that SwiftUI keeps out of the accessibility tree.
 
 ### InteractionEngine / MacOSInteractionEngine
 
@@ -105,6 +105,8 @@ Executes UI actions on the main thread:
 Uses platform-native event dispatch and direct view/control method calls. Scroll uses `UIScrollView.setContentOffset` on iOS and `NSScrollView` APIs on macOS.
 
 **iOS 26+ SwiftUI tap delivery (`APPREVEAL_PRIVATE_API_TAPS`):** On iOS 26+ SwiftUI's gesture engine runs entirely inside UIKit's window-level event dispatch; direct `touchesBegan`/`touchesEnded` calls on `_UIHostingView` are ignored. When the `APPREVEAL_PRIVATE_API_TAPS` compiler flag is defined, `tap_point` and `tap_element` on SwiftUI targets synthesise an `IOHIDDigitizerEvent` (hand + finger sub-event), bind it to the target window via `BKSHIDEventSetDigitizerInfo`, and inject via `UIApplication._enqueueHIDEvent:`. The entire implementation is inside `#if APPREVEAL_PRIVATE_API_TAPS` — no private API symbols appear in binaries built without the flag, making it safe for App Store review.
+
+**iOS SwiftUI text discovery fallback:** SwiftUI can render visible controls without exposing accessibility children to in-process scanners. On iOS, `OCRTextInventory` captures the current window, runs Vision text recognition, and keeps only text whose center falls inside a SwiftUI hosting view. These entries appear with `idSource: "ocr"` in `get_elements`/`get_view_tree`; `tap_text` can target them directly, and `tap_element` can derive text candidates from identifiers such as `device.chip.mouser` before tapping through the same SwiftUI-aware coordinate path.
 
 ### ScreenshotCapture / MacOSScreenshotCapture
 
@@ -323,7 +325,7 @@ iOS/                                   (single Swift package for iOS + macOS)
 ## Design principles
 
 1. **Convention over configuration** -- works with minimal setup if naming conventions are followed
-2. **Explicit over magic** -- no SwiftUI internal tree walking; private API gated behind `APPREVEAL_PRIVATE_API_TAPS` compile flag and compiled out by default
+2. **Explicit over magic** -- no SwiftUI internal tree walking; private tap delivery is gated behind `APPREVEAL_PRIVATE_API_TAPS`, and OCR fallback is labeled with `idSource: "ocr"` instead of pretending to recover hidden identifiers
 3. **Read-first** -- observation tools before mutation tools
 4. **Debug-only** -- zero production impact, compile-time guarantee
 5. **Standard transport** -- MCP Streamable HTTP for maximum client compatibility

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -63,11 +63,11 @@ If your team prefers zero private API usage even in debug builds, remove (or com
 
 Without the flag, `tap_point` still works for all UIKit views and SwiftUI views on iOS < 26. On iOS 26+ SwiftUI buttons will not respond to synthetic taps.
 
-### 2. Register SwiftUI elements (required on iOS 26+)
+### 2. Register SwiftUI elements when you need stable IDs or direct activation
 
-On iOS 26, SwiftUI defers building its accessibility tree until VoiceOver is actually running. AppReveal's in-process scan can't trigger that build, so SwiftUI buttons inside `UIHostingController` are invisible to `get_elements` by default.
+On iOS 26, SwiftUI can defer building its accessibility tree until an assistive technology is actually running. AppReveal first asks UIKit/SwiftUI for accessibility and automation elements. When those APIs still return an empty SwiftUI subtree, AppReveal falls back to Vision text recognition inside SwiftUI hosting views. This makes visible SwiftUI text appear in `get_elements` with `idSource: "ocr"` and lets `tap_text("Send")` tap the recognized text location.
 
-**Fix:** apply `.appReveal("id")` to SwiftUI views that agents need to interact with. For buttons in `ScrollView`, `LazyVGrid`, or other gesture-heavy containers, pass the optional `activate:` closure so AppReveal can invoke the debug action directly instead of depending on coordinate synthesis.
+For the most stable automation, apply `.appReveal("id")` to SwiftUI views that agents need to interact with. For buttons in `ScrollView`, `LazyVGrid`, or other gesture-heavy containers, pass the optional `activate:` closure so AppReveal can invoke the debug action directly instead of depending on coordinate synthesis.
 
 ```swift
 // Works on iOS 16+ — no-op in release (compiled only under #if DEBUG)
@@ -86,7 +86,7 @@ Button("Submit") { submit() }
 
 After this, `get_elements` returns the element with `idSource: "appReveal"` and `tap_element("chat.send_button")` or `tap_text("Send")` can find it. If an `activate:` closure is registered, AppReveal calls that closure directly; otherwise it falls back to the SwiftUI-aware coordinate path used by `tap_point`.
 
-**Elements without `.appReveal()`:** UIKit views (`UIButton`, `UITextField`, `UISwitch`, etc.) and SwiftUI elements with an `accessibilityIdentifier` set **on iOS < 26** continue to work automatically.
+**Elements without `.appReveal()`:** UIKit views (`UIButton`, `UITextField`, `UISwitch`, etc.) and SwiftUI elements that surface through accessibility or automation APIs continue to work automatically. On iOS 26+ SwiftUI views that stay hidden from those APIs can still be tapped by visible text through OCR. `tap_element` also tries OCR text candidates derived from the requested identifier, so IDs such as `device.chip.mouser` can fall back to visible text like `mouser`. OCR cannot recover an arbitrary hidden `accessibilityIdentifier`; use `.appReveal("stable.id")` when exact ID inventory matters.
 
 ### 3. Add Bonjour keys to `Info.plist`
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -81,7 +81,7 @@ List all visible interactive elements on the current screen.
 }
 ```
 
-- `idSource` — how the element's `id` was derived: `"explicit"` (accessibility identifier / tag / resource ID), `"appReveal"` (SwiftUI `.appReveal(...)` registration), `"text"` (from visible text), `"semantics"` (accessibility label / content description), `"tooltip"`, or `"derived"` (auto-generated fallback)
+- `idSource` — how the element's `id` was derived: `"explicit"` (accessibility identifier / tag / resource ID), `"appReveal"` (SwiftUI `.appReveal(...)` registration), `"ocr"` (Vision-recognized SwiftUI text fallback on iOS), `"text"` (from visible text), `"semantics"` (accessibility label / content description), `"tooltip"`, or `"derived"` (auto-generated fallback)
 - `safeAreaInsets` — per-view safe area insets using `leading` / `trailing` instead of physical `left` / `right`
 - `safeAreaLayoutGuideFrame` — the view's safe area layout guide frame in screen coordinates
 - Platform mapping: iOS/macOS use native safe areas, Android uses system bar/display-cutout insets, Flutter uses the nearest `MediaQuery.padding`
@@ -152,10 +152,12 @@ Tap an element by its identifier.
 
 **Response:** `{ "success": true, "element_id": "login.submit" }`
 
+On iOS, if SwiftUI does not expose a visible control through accessibility or automation APIs, `tap_element` falls back to OCR text candidates derived from the identifier. For example, `device.chip.mouser` can resolve to recognized text `mouser`.
+
 ---
 
 ### `tap_text`
-Tap an element by its visible text content. Finds text in the view hierarchy and walks up to the nearest tappable ancestor. Useful when elements lack accessibility identifiers.
+Tap an element by its visible text content. Finds text in the view hierarchy and walks up to the nearest tappable ancestor. On iOS, it also recognizes visible SwiftUI text inside hosting views when SwiftUI does not expose accessibility nodes. Useful when elements lack accessibility identifiers.
 
 **Parameters:**
 - `text` (string, required) — text to find

--- a/example/iOS/AppRevealExample/Screens/TapCalibrationViewController.swift
+++ b/example/iOS/AppRevealExample/Screens/TapCalibrationViewController.swift
@@ -71,6 +71,7 @@ final class TapCalibrationViewController: UIViewController {
     private func embedSwiftUIView() {
         let swiftUIVC = UIHostingController(rootView: SwiftUITapTestView(
             onTap: { [weak self] in self?.swiftUIButtonTapped() },
+            onIdentifierOnlyTap: { [weak self] in self?.swiftUIIdentifierOnlyButtonTapped() },
             onImageTap: { [weak self] in self?.swiftUIImageButtonTapped() }
         ))
         addChild(swiftUIVC)
@@ -109,10 +110,16 @@ final class TapCalibrationViewController: UIViewController {
         imageButtonResultLabel.text = "SwiftUI image button tapped!"
         imageButtonResultLabel.textColor = .systemOrange
     }
+
+    private func swiftUIIdentifierOnlyButtonTapped() {
+        resultLabel.text = "Identifier-only SwiftUI button tapped!"
+        resultLabel.textColor = .systemPurple
+    }
 }
 
 private struct SwiftUITapTestView: View {
     let onTap: () -> Void
+    let onIdentifierOnlyTap: () -> Void
     let onImageTap: () -> Void
 
     @State private var textFieldValue = ""
@@ -135,6 +142,9 @@ private struct SwiftUITapTestView: View {
                 #if DEBUG
                 .appReveal("calibration.swiftui_button", label: "Tap Me (SwiftUI)")
                 #endif
+                Button("Identifier Only", action: onIdentifierOnlyTap)
+                    .buttonStyle(.borderedProminent)
+                    .accessibilityIdentifier("calibration.swiftui_identifier_only")
                 // Image-only button — no label/identifier. Use .appReveal() for discovery on iOS 26+.
                 Button(action: onImageTap) {
                     Image(systemName: "arrow.up.circle.fill")

--- a/iOS/Sources/AppReveal/Elements/AccessibilityElementInventory.swift
+++ b/iOS/Sources/AppReveal/Elements/AccessibilityElementInventory.swift
@@ -266,17 +266,7 @@ final class AccessibilityElementInventory {
     ) {
         let resolvedContainerId = view.accessibilityIdentifier ?? containerId
 
-        // Prefer the modern accessibilityElements array — SwiftUI hosting views use this exclusively.
-        // Fall back to the deprecated count/index API for older UIKit patterns.
-        let rawElements: [Any]
-        if let arr = view.accessibilityElements, !arr.isEmpty {
-            rawElements = arr
-        } else {
-            let count = view.accessibilityElementCount()
-            // Guard against NSNotFound (Int.max) and empty containers.
-            guard count > 0, count < 100_000 else { return }
-            rawElements = (0..<count).compactMap { view.accessibilityElement(at: $0) }
-        }
+        guard let rawElements = rawContainerElements(for: view) else { return }
 
         for element in rawElements {
             guard let rawElement = element as? NSObject else { continue }
@@ -312,18 +302,7 @@ final class AccessibilityElementInventory {
         visited: inout Set<ObjectIdentifier>,
         visitor: (AccessibilityResolvedTarget) -> Void
     ) {
-        // SwiftUI virtual accessibility proxy nodes expose children via accessibilityElementCount /
-        // accessibilityElement(at:) rather than a KVC-accessible "accessibilityElements" key.
-        // Try the array property first; fall back to count/index for SwiftUI nodes.
-        let rawArr: [Any]
-        if let arr = element.value(forKey: "accessibilityElements") as? [Any], !arr.isEmpty {
-            rawArr = arr
-        } else {
-            let count = element.accessibilityElementCount()
-            guard count > 0, count < 100_000 else { return }
-            rawArr = (0..<count).compactMap { element.accessibilityElement(at: $0) }
-        }
-        guard !rawArr.isEmpty else { return }
+        guard let rawArr = rawContainerElements(for: element), !rawArr.isEmpty else { return }
 
         let subContainerId = accessibilityIdentifier(for: element) ?? containerId
         for sub in rawArr {
@@ -364,6 +343,22 @@ final class AccessibilityElementInventory {
             element: element,
             containerView: containerView
         )
+    }
+
+    private func rawContainerElements(for element: NSObject) -> [Any]? {
+        if #available(iOS 17.0, *), let automationElements = element.automationElements, !automationElements.isEmpty {
+            return automationElements
+        }
+        if let accessibilityElements = element.accessibilityElements, !accessibilityElements.isEmpty {
+            return accessibilityElements
+        }
+
+        // SwiftUI virtual accessibility proxy nodes expose children via accessibilityElementCount /
+        // accessibilityElement(at:) rather than a KVC-accessible "accessibilityElements" key.
+        // Guard against NSNotFound (Int.max) and empty containers.
+        let count = element.accessibilityElementCount()
+        guard count > 0, count < 100_000 else { return nil }
+        return (0..<count).compactMap { element.accessibilityElement(at: $0) }
     }
 
     private func resolveId(for element: NSObject) -> (String?, String) {

--- a/iOS/Sources/AppReveal/Elements/ElementInventory.swift
+++ b/iOS/Sources/AppReveal/Elements/ElementInventory.swift
@@ -34,6 +34,7 @@ final class ElementInventory {
             )
         }
         appendSwiftUIRegisteredElements(to: &elements, seenIds: &seenIds, windowIds: Set(windows.map(\.id)))
+        appendOCRTextElements(to: &elements, seenIds: &seenIds, windowId: windowId)
         return elements
     }
 
@@ -131,6 +132,10 @@ final class ElementInventory {
             return .appReveal(id: entry.id, point: entry.frame.center)
         }
 
+        if let ocrTarget = OCRTextInventory.shared.findElementIdFallback(id, windowId: windowId) {
+            return .point(ocrTarget.centerPoint)
+        }
+
         return nil
     }
 
@@ -173,6 +178,11 @@ final class ElementInventory {
         for entry in SwiftUIElementRegistry.shared.matchingElements(text: text, matchMode: matchMode, windowIds: windowIds) {
             resolvedTargets.append(.appReveal(id: entry.id, point: entry.frame.center))
             candidates.append(entry.label ?? entry.id)
+        }
+
+        for ocrTarget in OCRTextInventory.shared.matchingTextTargets(text, matchMode: matchMode, windowId: windowId) {
+            resolvedTargets.append(.point(ocrTarget.centerPoint))
+            candidates.append(ocrTarget.text)
         }
 
         if resolvedTargets.isEmpty {
@@ -446,6 +456,7 @@ final class ElementInventory {
             )
         }
         appendSwiftUIRegisteredViewTreeNodes(to: &result, windowIds: Set(windows.map(\.id)))
+        appendOCRTextViewTreeNodes(to: &result, windowId: windowId)
         return result
     }
 
@@ -662,6 +673,74 @@ final class ElementInventory {
                 node["accessibilityLabel"] = label
             }
             result.append(node)
+        }
+    }
+
+    private func appendOCRTextElements(to elements: inout [ElementInfo], seenIds: inout [String: Int], windowId: String?) {
+        var existingText = Set(
+            elements
+                .flatMap { [$0.id, $0.label ?? ""] }
+                .map { OCRTextInventory.normalized($0) }
+                .filter { !$0.isEmpty }
+        )
+
+        for target in OCRTextInventory.shared.textTargets(windowId: windowId) {
+            let normalizedText = OCRTextInventory.normalized(target.text)
+            guard !existingText.contains(normalizedText) else { continue }
+            existingText.insert(normalizedText)
+
+            let baseId = Self.normalizeToId(target.text)
+            let count = seenIds[baseId, default: 0]
+            seenIds[baseId] = count + 1
+            let finalId = count == 0 ? baseId : "\(baseId)_\(count)"
+            let frame = target.frame
+
+            elements.append(
+                ElementInfo(
+                    id: finalId,
+                    type: .button,
+                    label: target.text,
+                    value: nil,
+                    enabled: true,
+                    visible: !frame.isEmpty,
+                    tappable: true,
+                    frame: Self.makeFrame(frame),
+                    safeAreaInsets: ElementInfo.ElementInsets(top: 0, leading: 0, bottom: 0, trailing: 0),
+                    safeAreaLayoutGuideFrame: Self.makeFrame(frame),
+                    containerId: nil,
+                    actions: ["tap"],
+                    idSource: "ocr"
+                )
+            )
+        }
+    }
+
+    private func appendOCRTextViewTreeNodes(to result: inout [[String: Any]], windowId: String?) {
+        var existingText = Set(
+            result
+                .flatMap { [($0["accessibilityId"] as? String) ?? "", ($0["accessibilityLabel"] as? String) ?? ""] }
+                .map { OCRTextInventory.normalized($0) }
+                .filter { !$0.isEmpty }
+        )
+
+        for target in OCRTextInventory.shared.textTargets(windowId: windowId) {
+            let normalizedText = OCRTextInventory.normalized(target.text)
+            guard !existingText.contains(normalizedText) else { continue }
+            existingText.insert(normalizedText)
+
+            let frame = target.frame
+            result.append([
+                "class": "SwiftUI.OCRText",
+                "frame": "\(Int(frame.origin.x)),\(Int(frame.origin.y)),\(Int(frame.width)),\(Int(frame.height))",
+                "hidden": frame.isEmpty,
+                "alpha": 1,
+                "userInteraction": true,
+                "depth": 0,
+                "accessibilityId": Self.normalizeToId(target.text),
+                "accessibilityLabel": target.text,
+                "idSource": "ocr",
+                "actions": ["tap"]
+            ] as [String: Any])
         }
     }
 

--- a/iOS/Sources/AppReveal/Elements/OCRTextInventory.swift
+++ b/iOS/Sources/AppReveal/Elements/OCRTextInventory.swift
@@ -1,0 +1,230 @@
+// OCR fallback for SwiftUI text rendered without UIKit/accessibility nodes.
+
+import Foundation
+
+#if os(iOS)
+
+import UIKit
+import Vision
+
+#if DEBUG
+
+@MainActor
+struct OCRTextTarget {
+    let text: String
+    let frame: CGRect
+    let windowId: String
+
+    var centerPoint: CGPoint {
+        CGPoint(x: frame.midX, y: frame.midY)
+    }
+}
+
+@MainActor
+final class OCRTextInventory {
+
+    static let shared = OCRTextInventory()
+
+    private init() {}
+
+    func textTargets(windowId: String? = nil) -> [OCRTextTarget] {
+        IOSWindowProvider.shared.windowsForInteraction(windowId: windowId)
+            .flatMap { targets(in: $0) }
+            .sorted { lhs, rhs in
+                if abs(lhs.frame.minY - rhs.frame.minY) > 4 {
+                    return lhs.frame.minY < rhs.frame.minY
+                }
+                return lhs.frame.minX < rhs.frame.minX
+            }
+    }
+
+    func findTextTarget(
+        _ text: String,
+        matchMode: String = "exact",
+        occurrence: Int = 0,
+        windowId: String? = nil
+    ) -> OCRTextTarget? {
+        let matches = matchingTextTargets(text, matchMode: matchMode, windowId: windowId)
+        guard !matches.isEmpty else { return nil }
+        let index = matches.count == 1 ? 0 : max(0, occurrence)
+        guard index < matches.count else { return nil }
+        return matches[index]
+    }
+
+    func matchingTextTargets(
+        _ text: String,
+        matchMode: String = "exact",
+        windowId: String? = nil
+    ) -> [OCRTextTarget] {
+        textTargets(windowId: windowId).filter { target in
+            Self.matches(target.text, query: text, matchMode: matchMode)
+        }
+    }
+
+    func findElementIdFallback(_ elementId: String, windowId: String? = nil) -> OCRTextTarget? {
+        let targets = textTargets(windowId: windowId)
+        guard !targets.isEmpty else { return nil }
+
+        for candidate in Self.textCandidates(forElementId: elementId) {
+            if let exact = targets.first(where: { Self.matches($0.text, query: candidate, matchMode: "exact") }) {
+                return exact
+            }
+        }
+
+        for candidate in Self.textCandidates(forElementId: elementId).filter({ Self.normalized($0).count >= 4 }) {
+            if let contains = targets.first(where: { Self.matches($0.text, query: candidate, matchMode: "contains") }) {
+                return contains
+            }
+        }
+
+        return nil
+    }
+
+    static func normalized(_ text: String) -> String {
+        let scalarView = text.unicodeScalars.map { scalar -> Character in
+            CharacterSet.alphanumerics.contains(scalar)
+                ? Character(scalar)
+                : " "
+        }
+        return String(scalarView)
+            .lowercased()
+            .split(whereSeparator: \.isWhitespace)
+            .joined(separator: " ")
+    }
+
+    static func textCandidates(forElementId elementId: String) -> [String] {
+        let tokens = splitIdentifierIntoWords(elementId)
+        guard !tokens.isEmpty else { return [elementId] }
+
+        var candidates: [String] = []
+        func append(_ value: String) {
+            let normalizedValue = normalized(value)
+            guard !normalizedValue.isEmpty else { return }
+            if !candidates.contains(normalizedValue) {
+                candidates.append(normalizedValue)
+            }
+        }
+
+        append(elementId)
+
+        let separators = CharacterSet(charactersIn: "./:-")
+        if let lastSegment = elementId.components(separatedBy: separators).last {
+            append(lastSegment)
+            append(splitIdentifierIntoWords(lastSegment).joined(separator: " "))
+        }
+
+        for start in tokens.indices {
+            let suffix = tokens[start...].joined(separator: " ")
+            append(suffix)
+        }
+
+        if let last = tokens.last {
+            append(last)
+        }
+
+        return candidates
+    }
+
+    private func targets(in windowRef: WindowRef) -> [OCRTextTarget] {
+        let window = windowRef.nativeWindow
+        let hostingFrames = swiftUIHostingFrames(in: window)
+        guard !hostingFrames.isEmpty else { return [] }
+        guard let image = captureImage(in: window), let cgImage = image.cgImage else { return [] }
+
+        let request = VNRecognizeTextRequest()
+        request.recognitionLevel = .accurate
+        request.usesLanguageCorrection = false
+
+        let handler = VNImageRequestHandler(cgImage: cgImage, orientation: .up, options: [:])
+        do {
+            try handler.perform([request])
+        } catch {
+            return []
+        }
+
+        let windowBounds = window.bounds
+        return (request.results ?? []).compactMap { observation in
+            guard let recognized = observation.topCandidates(1).first else { return nil }
+            let text = recognized.string.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !text.isEmpty else { return nil }
+
+            let box = observation.boundingBox
+            let frame = CGRect(
+                x: box.minX * windowBounds.width,
+                y: (1 - box.maxY) * windowBounds.height,
+                width: box.width * windowBounds.width,
+                height: box.height * windowBounds.height
+            )
+            guard !frame.isEmpty else { return nil }
+            let center = CGPoint(x: frame.midX, y: frame.midY)
+            guard hostingFrames.contains(where: { $0.insetBy(dx: -4, dy: -4).contains(center) }) else {
+                return nil
+            }
+
+            return OCRTextTarget(text: text, frame: frame, windowId: windowRef.id)
+        }
+    }
+
+    private func captureImage(in window: UIWindow) -> UIImage? {
+        let format = UIGraphicsImageRendererFormat()
+        format.scale = window.screen.scale
+        let renderer = UIGraphicsImageRenderer(bounds: window.bounds, format: format)
+        return renderer.image { _ in
+            window.drawHierarchy(in: window.bounds, afterScreenUpdates: false)
+        }
+    }
+
+    private func swiftUIHostingFrames(in root: UIView) -> [CGRect] {
+        var frames: [CGRect] = []
+        collectSwiftUIHostingFrames(in: root, frames: &frames)
+        return frames
+    }
+
+    private func collectSwiftUIHostingFrames(in view: UIView, frames: inout [CGRect]) {
+        if Self.isSwiftUIHostingView(view) {
+            frames.append(view.convert(view.bounds, to: nil))
+        }
+        for subview in view.subviews where !subview.isHidden && subview.alpha > 0 {
+            collectSwiftUIHostingFrames(in: subview, frames: &frames)
+        }
+    }
+
+    private static func isSwiftUIHostingView(_ view: UIView) -> Bool {
+        let name = String(describing: type(of: view))
+        return name.contains("_UIHostingView") || name.contains("UIHostingView")
+    }
+
+    private static func matches(_ candidate: String, query: String, matchMode: String) -> Bool {
+        let normalizedCandidate = normalized(candidate)
+        let normalizedQuery = normalized(query)
+        guard !normalizedCandidate.isEmpty, !normalizedQuery.isEmpty else { return false }
+
+        switch matchMode {
+        case "contains":
+            return normalizedCandidate.contains(normalizedQuery)
+        default:
+            return normalizedCandidate == normalizedQuery
+        }
+    }
+
+    private static func splitIdentifierIntoWords(_ value: String) -> [String] {
+        let separated = value
+            .replacingOccurrences(
+                of: "([a-z0-9])([A-Z])",
+                with: "$1 $2",
+                options: .regularExpression
+            )
+            .replacingOccurrences(
+                of: "[^A-Za-z0-9]+",
+                with: " ",
+                options: .regularExpression
+            )
+        return separated
+            .split(whereSeparator: \.isWhitespace)
+            .map { String($0).lowercased() }
+    }
+}
+
+#endif
+
+#endif


### PR DESCRIPTION
## Summary
- add an iOS Vision OCR fallback scoped to SwiftUI hosting views when SwiftUI exposes no accessibility/automation children
- include OCR text nodes in get_elements/get_view_tree with idSource=ocr
- let tap_text target OCR SwiftUI text and let tap_element fall back from identifier suffixes such as device.chip.mouser to visible text
- add an iOS example fixture for a SwiftUI Button with only .accessibilityIdentifier("calibration.swiftui_identifier_only")

Fixes #44

## Verification
- swift test (iOS package): 19/19 passed
- XcodeBuildMCP build/run on iPhone 17 Pro Max Simulator: succeeded
- Live iOS AppReveal MCP:
  - get_elements includes Identifier Only as idSource=ocr
  - get_view_tree includes SwiftUI.OCRText for Identifier Only
  - tap_element calibration.swiftui_identifier_only succeeds and updates calibration.result
  - tap_text Identifier Only succeeds and updates calibration.result
- Android Gradle: :appreveal:testDebugUnitTest passed
- Android example: :app:assembleDebug passed
- Android Emulator emulator-5554: ./verify-compose-mcp.sh passed
- git diff --check passed