### PR TITLE
Fix iOS WebView DOM element driving

### DIFF
--- a/Android/appreveal/src/main/kotlin/com/appreveal/webview/DOMSerializer.kt
+++ b/Android/appreveal/src/main/kotlin/com/appreveal/webview/DOMSerializer.kt
@@ -76,30 +76,64 @@ internal object DOMSerializer {
                 var node = nodes[i];
                 var rect = node.getBoundingClientRect();
                 if (rect.width === 0 && rect.height === 0) continue;
+                var style = window.getComputedStyle(node);
+                if (style.display === 'none' || style.visibility === 'hidden') continue;
+                var testId = node.getAttribute('data-testid') || node.getAttribute('data-test') || node.getAttribute('data-cy');
+                var ariaLabel = node.getAttribute('aria-label') || '';
+                var text = (node.innerText || node.textContent || '').trim();
+                var tag = node.tagName.toLowerCase();
+                var role = node.getAttribute('role') || '';
+                var inputType = (node.getAttribute('type') || '').toLowerCase();
+                var labelText = labelTextFor(node);
                 var el = {
-                    tag: node.tagName.toLowerCase(),
+                    index: i,
+                    tag: tag,
+                    role: role,
                     rect: {x:Math.round(rect.x),y:Math.round(rect.y),w:Math.round(rect.width),h:Math.round(rect.height)},
-                    selector: genSelector(node)
+                    selector: genSelector(node),
+                    label: (ariaLabel || labelText || text || node.placeholder || node.value || node.title || node.name || node.id || testId || '').substring(0, 200),
+                    enabled: !node.disabled,
+                    visible: true,
+                    tappable: isTappable(node, tag, role, inputType),
+                    actions: actionsFor(node, tag, role, inputType)
                 };
                 if (node.id) el.id = node.id;
                 if (node.name) el.name = node.name;
-                if (node.type) el.type = node.type;
+                if (node.type) el.inputType = node.type;
                 if (node.placeholder) el.placeholder = node.placeholder;
                 if (node.value) el.value = node.value.substring(0, 200);
-                var text = node.textContent.trim();
                 if (text) el.text = text.substring(0, 100);
-                var testId = node.getAttribute('data-testid') || node.getAttribute('data-test') || node.getAttribute('data-cy');
+                if (labelText) el.labelText = labelText.substring(0, 100);
                 if (testId) el.testId = testId;
-                if (node.getAttribute('aria-label')) el.ariaLabel = node.getAttribute('aria-label');
+                if (ariaLabel) el.ariaLabel = ariaLabel;
                 if (node.disabled) el.disabled = true;
                 if (node.checked !== undefined) el.checked = node.checked;
                 if (node.href) el.href = node.href;
                 results.push(el);
             }
+            function cssEscape(value) {
+                if (window.CSS && typeof window.CSS.escape === 'function') return window.CSS.escape(value);
+                return String(value).replace(/["\\]/g, '\\$&').replace(/[^a-zA-Z0-9_-]/g, '\\$&');
+            }
+            function labelTextFor(el) {
+                if (el.labels && el.labels.length) {
+                    return Array.from(el.labels).map(function(label) {
+                        return (label.innerText || label.textContent || '').trim();
+                    }).filter(Boolean).join(' ');
+                }
+                if (el.id) {
+                    var explicit = document.querySelector('label[for="' + cssEscape(el.id) + '"]');
+                    if (explicit) return (explicit.innerText || explicit.textContent || '').trim();
+                }
+                var parentLabel = el.closest('label');
+                return parentLabel ? (parentLabel.innerText || parentLabel.textContent || '').trim() : '';
+            }
             function genSelector(el) {
-                if (el.getAttribute('data-testid')) return '[data-testid="' + el.getAttribute('data-testid') + '"]';
-                if (el.id) return '#' + el.id;
-                if (el.name) return el.tagName.toLowerCase() + '[name="' + el.name + '"]';
+                if (el.getAttribute('data-testid')) return '[data-testid="' + cssEscape(el.getAttribute('data-testid')) + '"]';
+                if (el.getAttribute('data-test')) return '[data-test="' + cssEscape(el.getAttribute('data-test')) + '"]';
+                if (el.getAttribute('data-cy')) return '[data-cy="' + cssEscape(el.getAttribute('data-cy')) + '"]';
+                if (el.id) return '#' + cssEscape(el.id);
+                if (el.name) return el.tagName.toLowerCase() + '[name="' + cssEscape(el.name) + '"]';
                 var path = [];
                 while (el && el !== document.body) {
                     var tag = el.tagName.toLowerCase();
@@ -116,7 +150,34 @@ internal object DOMSerializer {
                 }
                 return path.join(' > ');
             }
-            return JSON.stringify({elements: results, count: results.length});
+            function isTappable(node, tag, role, inputType) {
+                if (node.disabled) return false;
+                return tag === 'button' || tag === 'a' || tag === 'select' || tag === 'label' ||
+                    role === 'button' || role === 'link' || !!node.onclick ||
+                    inputType === 'button' || inputType === 'submit' || inputType === 'reset' ||
+                    inputType === 'checkbox' || inputType === 'radio' ||
+                    node.tabIndex >= 0;
+            }
+            function actionsFor(node, tag, role, inputType) {
+                var actions = [];
+                if (isTappable(node, tag, role, inputType)) actions.push('tap');
+                if (tag === 'textarea' || (tag === 'input' && !['button','submit','reset','checkbox','radio','hidden','file'].includes(inputType))) {
+                    actions.push('type');
+                    actions.push('clear');
+                }
+                if (tag === 'select') actions.push('select');
+                return actions;
+            }
+            return JSON.stringify({
+                elements: results,
+                count: results.length,
+                viewport: {
+                    width: Math.max(1, window.innerWidth || document.documentElement.clientWidth || 1),
+                    height: Math.max(1, window.innerHeight || document.documentElement.clientHeight || 1)
+                },
+                title: document.title || '',
+                url: location.href
+            });
         })()
         """.trimIndent()
 
@@ -216,8 +277,31 @@ internal object DOMSerializer {
         (function() {
             var el = document.querySelector('${escapeJS(selector)}');
             if (!el) return JSON.stringify({error:'Element not found: ${escapeJS(selector)}'});
+            var rect = el.getBoundingClientRect();
+            var x = rect.left + rect.width / 2;
+            var y = rect.top + rect.height / 2;
+            if (typeof el.focus === 'function') {
+                try { el.focus({preventScroll:true}); } catch (_) { el.focus(); }
+            }
+            var eventInit = {bubbles:true, cancelable:true, view:window, clientX:x, clientY:y};
+            if (typeof PointerEvent !== 'undefined') {
+                el.dispatchEvent(new PointerEvent('pointerdown', Object.assign({pointerId:1, pointerType:'mouse', isPrimary:true}, eventInit)));
+                el.dispatchEvent(new PointerEvent('pointerup', Object.assign({pointerId:1, pointerType:'mouse', isPrimary:true}, eventInit)));
+            }
+            el.dispatchEvent(new MouseEvent('mousedown', eventInit));
+            el.dispatchEvent(new MouseEvent('mouseup', eventInit));
             el.click();
-            return JSON.stringify({success:true, tag:el.tagName.toLowerCase(), text:el.textContent.trim().substring(0,100)});
+            if (el.checked !== undefined) {
+                el.dispatchEvent(new Event('input', {bubbles:true}));
+                el.dispatchEvent(new Event('change', {bubbles:true}));
+            }
+            return JSON.stringify({
+                success:true,
+                tag:el.tagName.toLowerCase(),
+                text:(el.innerText || el.textContent || el.value || '').trim().substring(0,100),
+                checked: el.checked,
+                value: el.value
+            });
         })()
         """.trimIndent()
 

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ All native UI tools and all web view tools accept an optional `window_id` parame
 
 iOS/macOS/Android: auto-discovers WebViews from the view hierarchy. Flutter: register via `AppReveal.registerWebView(id, controller)`.
 
+On iOS and React Native iOS, visible interactive DOM controls inside `WKWebView` also appear in `get_elements` with `idSource: "dom"` and work with `tap_element`, `tap_text`, `type_text`, and `clear_text`. `tap_point` over a WebView routes through DOM `elementFromPoint(...)` so full-screen WebView shells can still be driven when UIKit text-editing overlays are present.
+
 | Tool | Description |
 |------|-------------|
 | `get_webviews` | List all web views with URL, title, loading state |

--- a/ReactNative/appreveal/README.md
+++ b/ReactNative/appreveal/README.md
@@ -14,7 +14,7 @@ if (__DEV__) {
 }
 ```
 
-The package exposes native iOS and Android MCP servers in debug builds, including native UI inspection, screenshots, interactions, state/navigation snapshots, network capture, and WKWebView/Android WebView DOM tools. React Native Windows is intentionally not autolinked until a real Windows MCP bridge is available.
+The package exposes native iOS and Android MCP servers in debug builds, including native UI inspection, screenshots, interactions, state/navigation snapshots, network capture, and WKWebView/Android WebView DOM tools. On iOS, visible interactive DOM controls inside `react-native-webview` appear in `get_elements` with DOM-backed IDs, and those IDs work with `tap_element`, `tap_text`, `type_text`, and `clear_text`. React Native Windows is intentionally not autolinked until a real Windows MCP bridge is available.
 
 See the React Native guide in the repository for setup notes:
 https://github.com/UnlikeOtherAI/AppReveal/blob/main/ReactNative/README.md

--- a/ReactNative/appreveal/ios/DOMSerializer.swift
+++ b/ReactNative/appreveal/ios/DOMSerializer.swift
@@ -71,30 +71,49 @@ enum DOMSerializer {
                 var node = nodes[i];
                 var rect = node.getBoundingClientRect();
                 if (rect.width === 0 && rect.height === 0) continue;
+                var style = window.getComputedStyle(node);
+                if (style.display === 'none' || style.visibility === 'hidden') continue;
+                var testId = node.getAttribute('data-testid') || node.getAttribute('data-test') || node.getAttribute('data-cy');
+                var ariaLabel = node.getAttribute('aria-label') || '';
+                var text = (node.innerText || node.textContent || '').trim();
+                var tag = node.tagName.toLowerCase();
+                var role = node.getAttribute('role') || '';
+                var inputType = (node.getAttribute('type') || '').toLowerCase();
                 var el = {
-                    tag: node.tagName.toLowerCase(),
+                    index: i,
+                    tag: tag,
+                    role: role,
                     rect: {x:Math.round(rect.x),y:Math.round(rect.y),w:Math.round(rect.width),h:Math.round(rect.height)},
-                    selector: genSelector(node)
+                    selector: genSelector(node),
+                    label: (ariaLabel || text || node.placeholder || node.value || node.title || node.name || node.id || testId || '').substring(0, 200),
+                    enabled: !node.disabled,
+                    visible: true,
+                    tappable: isTappable(node, tag, role, inputType),
+                    actions: actionsFor(node, tag, role, inputType)
                 };
                 if (node.id) el.id = node.id;
                 if (node.name) el.name = node.name;
-                if (node.type) el.type = node.type;
+                if (node.type) el.inputType = node.type;
                 if (node.placeholder) el.placeholder = node.placeholder;
                 if (node.value) el.value = node.value.substring(0, 200);
-                var text = node.textContent.trim();
                 if (text) el.text = text.substring(0, 100);
-                var testId = node.getAttribute('data-testid') || node.getAttribute('data-test') || node.getAttribute('data-cy');
                 if (testId) el.testId = testId;
-                if (node.getAttribute('aria-label')) el.ariaLabel = node.getAttribute('aria-label');
+                if (ariaLabel) el.ariaLabel = ariaLabel;
                 if (node.disabled) el.disabled = true;
                 if (node.checked !== undefined) el.checked = node.checked;
                 if (node.href) el.href = node.href;
                 results.push(el);
             }
+            function cssEscape(value) {
+                if (window.CSS && typeof window.CSS.escape === 'function') return window.CSS.escape(value);
+                return String(value).replace(/["\\\\]/g, '\\\\$&').replace(/[^a-zA-Z0-9_-]/g, '\\\\$&');
+            }
             function genSelector(el) {
-                if (el.getAttribute('data-testid')) return '[data-testid=\"' + el.getAttribute('data-testid') + '\"]';
-                if (el.id) return '#' + el.id;
-                if (el.name) return el.tagName.toLowerCase() + '[name=\"' + el.name + '\"]';
+                if (el.getAttribute('data-testid')) return '[data-testid=\"' + cssEscape(el.getAttribute('data-testid')) + '\"]';
+                if (el.getAttribute('data-test')) return '[data-test=\"' + cssEscape(el.getAttribute('data-test')) + '\"]';
+                if (el.getAttribute('data-cy')) return '[data-cy=\"' + cssEscape(el.getAttribute('data-cy')) + '\"]';
+                if (el.id) return '#' + cssEscape(el.id);
+                if (el.name) return el.tagName.toLowerCase() + '[name=\"' + cssEscape(el.name) + '\"]';
                 var path = [];
                 while (el && el !== document.body) {
                     var tag = el.tagName.toLowerCase();
@@ -111,7 +130,34 @@ enum DOMSerializer {
                 }
                 return path.join(' > ');
             }
-            return JSON.stringify({elements: results, count: results.length});
+            function isTappable(node, tag, role, inputType) {
+                if (node.disabled) return false;
+                return tag === 'button' || tag === 'a' || tag === 'select' || tag === 'label' ||
+                    role === 'button' || role === 'link' || !!node.onclick ||
+                    inputType === 'button' || inputType === 'submit' || inputType === 'reset' ||
+                    inputType === 'checkbox' || inputType === 'radio' ||
+                    node.tabIndex >= 0;
+            }
+            function actionsFor(node, tag, role, inputType) {
+                var actions = [];
+                if (isTappable(node, tag, role, inputType)) actions.push('tap');
+                if (tag === 'textarea' || (tag === 'input' && !['button','submit','reset','checkbox','radio','hidden','file'].includes(inputType))) {
+                    actions.push('type');
+                    actions.push('clear');
+                }
+                if (tag === 'select') actions.push('select');
+                return actions;
+            }
+            return JSON.stringify({
+                elements: results,
+                count: results.length,
+                viewport: {
+                    width: Math.max(1, window.innerWidth || document.documentElement.clientWidth || 1),
+                    height: Math.max(1, window.innerHeight || document.documentElement.clientHeight || 1)
+                },
+                title: document.title || '',
+                url: location.href
+            });
         })()
         """
     }
@@ -207,8 +253,31 @@ enum DOMSerializer {
         (function() {
             var el = document.querySelector('\(escapeJS(selector))');
             if (!el) return JSON.stringify({error:'Element not found: \(escapeJS(selector))'});
+            var rect = el.getBoundingClientRect();
+            var x = rect.left + rect.width / 2;
+            var y = rect.top + rect.height / 2;
+            if (typeof el.focus === 'function') {
+                try { el.focus({preventScroll:true}); } catch (_) { el.focus(); }
+            }
+            var eventInit = {bubbles:true, cancelable:true, view:window, clientX:x, clientY:y};
+            if (typeof PointerEvent !== 'undefined') {
+                el.dispatchEvent(new PointerEvent('pointerdown', Object.assign({pointerId:1, pointerType:'mouse', isPrimary:true}, eventInit)));
+                el.dispatchEvent(new PointerEvent('pointerup', Object.assign({pointerId:1, pointerType:'mouse', isPrimary:true}, eventInit)));
+            }
+            el.dispatchEvent(new MouseEvent('mousedown', eventInit));
+            el.dispatchEvent(new MouseEvent('mouseup', eventInit));
             el.click();
-            return JSON.stringify({success:true, tag:el.tagName.toLowerCase(), text:el.textContent.trim().substring(0,100)});
+            if (el.checked !== undefined) {
+                el.dispatchEvent(new Event('input', {bubbles:true}));
+                el.dispatchEvent(new Event('change', {bubbles:true}));
+            }
+            return JSON.stringify({
+                success:true,
+                tag:el.tagName.toLowerCase(),
+                text:(el.innerText || el.textContent || el.value || '').trim().substring(0,100),
+                checked: el.checked,
+                value: el.value
+            });
         })()
         """
     }

--- a/ReactNative/appreveal/ios/ElementInventory.swift
+++ b/ReactNative/appreveal/ios/ElementInventory.swift
@@ -24,6 +24,13 @@ final class ElementInventory {
         return elements
     }
 
+    func listElementsIncludingWebContent() async -> [ElementInfo] {
+        var elements = listElements()
+        let domTargets = await WebViewBridge.shared.domElementTargets()
+        elements.append(contentsOf: domTargets.map(\.elementInfo))
+        return elements
+    }
+
     func findElement(byId id: String) -> UIView? {
         for window in candidateWindows() {
             if let view = findView(withAccessibilityId: id, in: window) {

--- a/ReactNative/appreveal/ios/InteractionEngine.swift
+++ b/ReactNative/appreveal/ios/InteractionEngine.swift
@@ -62,6 +62,11 @@ final class InteractionEngine {
         for window in candidateWindows() {
             let hitView = window.hitTest(point, with: nil)
 
+            if isTextEditingOverlay(window: window, hitView: hitView),
+               WebViewBridge.shared.clickElement(at: point) {
+                return true
+            }
+
             if let webView = findParent(of: hitView, type: WKWebView.self),
                WebViewBridge.shared.clickElement(at: point, in: webView) {
                 return true
@@ -145,6 +150,23 @@ final class InteractionEngine {
             current = v.superview
         }
         return nil
+    }
+
+    private func isTextEditingOverlay(window: UIWindow, hitView: UIView?) -> Bool {
+        var names = [String(describing: Swift.type(of: window)).lowercased()]
+        var current = hitView
+        var depth = 0
+        while let view = current, depth < 12 {
+            names.append(String(describing: Swift.type(of: view)).lowercased())
+            current = view.superview
+            depth += 1
+        }
+        return names.contains { name in
+            name.contains("texteffects") ||
+            name.contains("editingoverlay") ||
+            name.contains("inputset") ||
+            name.contains("keyboard")
+        }
     }
 
     // MARK: - Text

--- a/ReactNative/appreveal/ios/MCPTools.swift
+++ b/ReactNative/appreveal/ios/MCPTools.swift
@@ -38,7 +38,8 @@ func registerBuiltInTools() {
         inputSchema: ["type": AnyCodable("object"), "properties": AnyCodable([String: Any]())],
         handler: { _ in
             let elements = ElementInventory.shared.listElements()
-            let list = elements.map { el in
+            let domTargets = await WebViewBridge.shared.domElementTargets()
+            var list = elements.map { el in
                 [
                     "id": el.id,
                     "type": el.type.rawValue,
@@ -64,6 +65,35 @@ func registerBuiltInTools() {
                     "idSource": el.idSource
                 ] as [String: Any]
             }
+            list.append(contentsOf: domTargets.map { target in
+                [
+                    "id": target.id,
+                    "type": target.type.rawValue,
+                    "label": target.label ?? "",
+                    "value": target.value ?? "",
+                    "enabled": target.enabled ? "true" : "false",
+                    "visible": target.frame.isEmpty ? "false" : "true",
+                    "tappable": target.actions.contains("tap") ? "true" : "false",
+                    "frame": "\(Int(target.frame.origin.x)),\(Int(target.frame.origin.y)),\(Int(target.frame.width)),\(Int(target.frame.height))",
+                    "safeAreaInsets": [
+                        "top": 0,
+                        "leading": 0,
+                        "bottom": 0,
+                        "trailing": 0
+                    ],
+                    "safeAreaLayoutGuideFrame": [
+                        "x": target.frame.origin.x,
+                        "y": target.frame.origin.y,
+                        "width": target.frame.width,
+                        "height": target.frame.height
+                    ],
+                    "actions": target.actions.joined(separator: ","),
+                    "idSource": "dom",
+                    "source": "webview",
+                    "webviewId": target.webViewId,
+                    "selector": target.selector
+                ] as [String: Any]
+            })
             return AnyCodable(["screenKey": ScreenResolver.shared.resolve().screenKey, "elements": list] as [String: Any])
         }
     ))
@@ -123,6 +153,14 @@ func registerBuiltInTools() {
                 try InteractionEngine.shared.tap(elementId: elementId)
                 return AnyCodable(["success": true, "element_id": elementId] as [String: Any])
             } catch {
+                if let target = await WebViewBridge.shared.findDOMElementTarget(id: elementId),
+                   WebViewBridge.shared.clickElement(target) {
+                    return AnyCodable([
+                        "success": true,
+                        "element_id": elementId,
+                        "target": "webview_dom"
+                    ] as [String: Any])
+                }
                 return AnyCodable(["error": "\(error.localizedDescription). Try tap_text for visible text targeting, or get_elements to list available IDs."])
             }
         }
@@ -154,6 +192,35 @@ func registerBuiltInTools() {
             )
 
             guard result.isSuccess, let view = result.view else {
+                let domMatches = await WebViewBridge.shared.matchingDOMElementTargets(
+                    text: text,
+                    matchMode: matchMode
+                )
+                if !domMatches.isEmpty {
+                    if domMatches.count > 1 && occurrence >= domMatches.count {
+                        return AnyCodable([
+                            "error": "occurrence \(occurrence) out of range (found \(domMatches.count) DOM matches)",
+                            "candidates": domMatches.map { $0.label ?? $0.id },
+                            "hint": "Use occurrence parameter (0-based) to select a specific match"
+                        ] as [String: Any])
+                    }
+                    if domMatches.count > 1 && occurrence < 0 {
+                        return AnyCodable([
+                            "error": "Ambiguous: \(domMatches.count) DOM matches found. Use occurrence (0-based) to disambiguate.",
+                            "candidates": domMatches.map { $0.label ?? $0.id },
+                            "hint": "Use occurrence parameter (0-based) to select a specific match"
+                        ] as [String: Any])
+                    }
+                    let index = domMatches.count == 1 ? 0 : occurrence
+                    if WebViewBridge.shared.clickElement(domMatches[index]) {
+                        return AnyCodable([
+                            "success": true,
+                            "text": text,
+                            "target": "webview_dom"
+                        ] as [String: Any])
+                    }
+                }
+
                 var response: [String: Any] = ["error": result.error ?? "Unknown error"]
                 if let candidates = result.candidates {
                     response["candidates"] = candidates

--- a/ReactNative/appreveal/ios/WebViewBridge.swift
+++ b/ReactNative/appreveal/ios/WebViewBridge.swift
@@ -5,6 +5,53 @@ import UIKit
 import WebKit
 
 @MainActor
+struct DOMElementTarget {
+    let id: String
+    let webViewId: String
+    let selector: String
+    let type: ElementType
+    let label: String?
+    let value: String?
+    let enabled: Bool
+    let frame: CGRect
+    let actions: [String]
+    let textCandidates: [String]
+
+    var centerPoint: CGPoint {
+        CGPoint(x: frame.midX, y: frame.midY)
+    }
+
+    var elementInfo: ElementInfo {
+        ElementInfo(
+            id: id,
+            type: type,
+            label: label,
+            value: value,
+            enabled: enabled,
+            visible: frame.width > 0 && frame.height > 0,
+            tappable: actions.contains("tap"),
+            frame: ElementInventory.makeFrame(frame),
+            safeAreaInsets: ElementInfo.ElementInsets(top: 0, leading: 0, bottom: 0, trailing: 0),
+            safeAreaLayoutGuideFrame: ElementInventory.makeFrame(frame),
+            containerId: webViewId,
+            actions: actions,
+            idSource: "dom"
+        )
+    }
+
+    func matches(text query: String, matchMode: String) -> Bool {
+        textCandidates.contains { candidate in
+            switch matchMode {
+            case "contains":
+                return candidate.localizedCaseInsensitiveContains(query)
+            default:
+                return candidate == query
+            }
+        }
+    }
+}
+
+@MainActor
 final class WebViewBridge {
 
     static let shared = WebViewBridge()
@@ -99,6 +146,151 @@ final class WebViewBridge {
         return true
     }
 
+    @discardableResult
+    func clickElement(selector: String, webViewId: String?) -> Bool {
+        guard let webView = resolveWebView(id: webViewId) else {
+            return false
+        }
+        webView.evaluateJavaScript(DOMSerializer.clickJS(selector: selector)) { _, error in
+            if let error {
+                print("[AppReveal] WebView DOM click failed: \(error.localizedDescription)")
+            }
+        }
+        return true
+    }
+
+    @discardableResult
+    func clickElement(_ target: DOMElementTarget) -> Bool {
+        clickElement(selector: target.selector, webViewId: target.webViewId)
+    }
+
+    @discardableResult
+    func typeText(_ text: String, in target: DOMElementTarget, clear: Bool) -> Bool {
+        guard target.actions.contains("type"),
+              let webView = resolveWebView(id: target.webViewId) else {
+            return false
+        }
+        webView.evaluateJavaScript(DOMSerializer.typeJS(selector: target.selector, text: text, clear: clear)) { _, error in
+            if let error {
+                print("[AppReveal] WebView DOM type failed: \(error.localizedDescription)")
+            }
+        }
+        return true
+    }
+
+    @discardableResult
+    func clearText(in target: DOMElementTarget) -> Bool {
+        typeText("", in: target, clear: true)
+    }
+
+    func domElementTargets() async -> [DOMElementTarget] {
+        var targets: [DOMElementTarget] = []
+        var seenIds: [String: Int] = [:]
+
+        for item in findWebViews() {
+            guard let payload = try? await interactivePayload(for: item.webView),
+                  let rawElements = payload["elements"] as? [[String: Any]] else {
+                continue
+            }
+
+            let viewport = payload["viewport"] as? [String: Any]
+            let viewportWidth = Self.cgFloat(viewport?["w"])
+                ?? Self.cgFloat(viewport?["width"])
+                ?? max(item.webView.bounds.width, 1)
+            let viewportHeight = Self.cgFloat(viewport?["h"])
+                ?? Self.cgFloat(viewport?["height"])
+                ?? max(item.webView.bounds.height, 1)
+            let scaleX = item.webView.bounds.width / max(viewportWidth, 1)
+            let scaleY = item.webView.bounds.height / max(viewportHeight, 1)
+            let webViewFrame = item.webView.convert(item.webView.bounds, to: nil)
+
+            for (index, raw) in rawElements.enumerated() {
+                guard let selector = Self.string(raw["selector"]),
+                      let rect = raw["rect"] as? [String: Any],
+                      let x = Self.cgFloat(rect["x"]),
+                      let y = Self.cgFloat(rect["y"]),
+                      let width = Self.cgFloat(rect["w"]),
+                      let height = Self.cgFloat(rect["h"]) else {
+                    continue
+                }
+
+                let frame = CGRect(
+                    x: webViewFrame.origin.x + (x * scaleX),
+                    y: webViewFrame.origin.y + (y * scaleY),
+                    width: width * scaleX,
+                    height: height * scaleY
+                )
+                guard frame.width > 0 || frame.height > 0 else { continue }
+
+                let tag = Self.string(raw["tag"])?.lowercased() ?? "element"
+                let inputType = (
+                    Self.string(raw["inputType"]) ?? Self.string(raw["type"])
+                )?.lowercased()
+                let label = Self.firstNonEmpty([
+                    Self.string(raw["label"]),
+                    Self.string(raw["ariaLabel"]),
+                    Self.string(raw["text"]),
+                    Self.string(raw["placeholder"]),
+                    Self.string(raw["name"]),
+                    Self.string(raw["id"]),
+                    Self.string(raw["testId"])
+                ])
+                let value = Self.string(raw["value"])
+                let enabledValue = raw["enabled"] as? Bool
+                let disabled = (raw["disabled"] as? Bool) == true || enabledValue == false
+                let type = Self.elementType(tag: tag, inputType: inputType)
+                let actions = Self.actions(for: type, enabled: !disabled)
+                let rawId = Self.firstNonEmpty([
+                    Self.string(raw["testId"]),
+                    Self.string(raw["id"]),
+                    Self.string(raw["name"]).map { "\(tag)_\($0)" },
+                    Self.string(raw["ariaLabel"]),
+                    Self.string(raw["placeholder"]),
+                    Self.string(raw["text"]),
+                    "\(tag)_\(index)"
+                ]) ?? "\(tag)_\(index)"
+                let id = Self.deduplicatedId(
+                    "web.\(Self.normalizeIdComponent(item.id)).\(Self.normalizeIdComponent(rawId))",
+                    seenIds: &seenIds
+                )
+                let textCandidates = [
+                    Self.string(raw["text"]),
+                    Self.string(raw["ariaLabel"]),
+                    Self.string(raw["placeholder"]),
+                    Self.string(raw["value"]),
+                    Self.string(raw["name"]),
+                    Self.string(raw["id"]),
+                    Self.string(raw["testId"])
+                ].compactMap { $0 }.filter { !$0.isEmpty }
+
+                targets.append(
+                    DOMElementTarget(
+                        id: id,
+                        webViewId: item.id,
+                        selector: selector,
+                        type: type,
+                        label: label,
+                        value: value,
+                        enabled: !disabled,
+                        frame: frame,
+                        actions: actions,
+                        textCandidates: textCandidates
+                    )
+                )
+            }
+        }
+
+        return targets
+    }
+
+    func findDOMElementTarget(id: String) async -> DOMElementTarget? {
+        await domElementTargets().first { $0.id == id }
+    }
+
+    func matchingDOMElementTargets(text: String, matchMode: String = "exact") async -> [DOMElementTarget] {
+        await domElementTargets().filter { $0.matches(text: text, matchMode: matchMode) }
+    }
+
     // MARK: - Metadata
 
     func webViewInfo() -> [[String: Any]] {
@@ -130,6 +322,94 @@ final class WebViewBridge {
         // For non-string results, convert to JSON
         let data = try JSONSerialization.data(withJSONObject: result, options: [])
         return String(data: data, encoding: .utf8) ?? "null"
+    }
+
+    private func interactivePayload(for webView: WKWebView) async throws -> [String: Any] {
+        let result = try await webView.evaluateJavaScript(DOMSerializer.interactiveJS())
+        let json: String
+        if let string = result as? String {
+            json = string
+        } else {
+            let data = try JSONSerialization.data(withJSONObject: result, options: [])
+            json = String(data: data, encoding: .utf8) ?? "{}"
+        }
+        guard let data = json.data(using: .utf8),
+              let payload = try JSONSerialization.jsonObject(with: data) as? [String: Any] else {
+            return [:]
+        }
+        return payload
+    }
+
+    private static func elementType(tag: String, inputType: String?) -> ElementType {
+        switch tag {
+        case "button", "a":
+            return .button
+        case "textarea":
+            return .textField
+        case "select":
+            return .picker
+        case "input":
+            switch inputType {
+            case "checkbox", "radio":
+                return .toggle
+            case "button", "submit", "reset":
+                return .button
+            default:
+                return .textField
+            }
+        default:
+            return .other
+        }
+    }
+
+    private static func actions(for type: ElementType, enabled: Bool) -> [String] {
+        guard enabled else { return [] }
+        switch type {
+        case .textField:
+            return ["tap", "type", "clear"]
+        case .picker:
+            return ["tap", "select"]
+        default:
+            return ["tap"]
+        }
+    }
+
+    private static func firstNonEmpty(_ values: [String?]) -> String? {
+        values.compactMap { value in
+            let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed?.isEmpty == false ? trimmed : nil
+        }.first
+    }
+
+    private static func string(_ value: Any?) -> String? {
+        if let string = value as? String { return string }
+        if let number = value as? NSNumber { return number.stringValue }
+        return nil
+    }
+
+    private static func cgFloat(_ value: Any?) -> CGFloat? {
+        if let number = value as? NSNumber { return CGFloat(truncating: number) }
+        if let double = value as? Double { return CGFloat(double) }
+        if let string = value as? String, let double = Double(string) { return CGFloat(double) }
+        return nil
+    }
+
+    private static func normalizeIdComponent(_ value: String) -> String {
+        var normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        normalized = normalized.replacingOccurrences(
+            of: "\\s+", with: "_", options: .regularExpression
+        )
+        normalized = normalized.replacingOccurrences(
+            of: "[^a-z0-9_.-]", with: "", options: .regularExpression
+        )
+        normalized = normalized.trimmingCharacters(in: CharacterSet(charactersIn: "._-"))
+        return normalized.isEmpty ? "element" : String(normalized.prefix(80))
+    }
+
+    private static func deduplicatedId(_ id: String, seenIds: inout [String: Int]) -> String {
+        let count = seenIds[id, default: 0]
+        seenIds[id] = count + 1
+        return count == 0 ? id : "\(id)_\(count)"
     }
 
     private func candidateWindows() -> [UIWindow] {

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,7 +116,7 @@ Optional element-level cropping by accessibility identifier.
 
 ### WebViewBridge / MacOSWebViewBridge
 
-Discovers `WKWebView` instances inside the selected window and powers the DOM tools. Native `get_elements` reports the WebView as a native view; DOM content is intentionally exposed through the WebView tools. On iOS, `tap_point` can route a coordinate inside a `WKWebView` to `document.elementFromPoint(...).click()` for mixed native/web flows.
+Discovers `WKWebView` instances inside the selected window and powers the DOM tools. On iOS and React Native iOS, `get_elements` also projects visible interactive DOM controls as DOM-backed AppReveal elements (`idSource: "dom"`) so `tap_element`, `tap_text`, `type_text`, and `clear_text` can drive WebView forms without a separate selector lookup. On iOS, `tap_point` routes coordinates inside a `WKWebView` to `document.elementFromPoint(...).click()` using WebView geometry, which avoids UIKit text-editing overlays swallowing WebView taps.
 
 - Auto-discovers web views from the native view hierarchy
 - Evaluates JavaScript for DOM inspection and interaction

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -185,7 +185,7 @@ Tap at specific screen coordinates.
 
 **Response:** `{ "success": true }`
 
-On iOS, when the point lands inside a `WKWebView`, AppReveal routes the coordinate to a DOM click through `document.elementFromPoint(...)`. Use `web_click` with a selector when you need deterministic DOM-level confirmation.
+On iOS, when the point lands inside a `WKWebView`, AppReveal routes the coordinate to a DOM click through `document.elementFromPoint(...)` and returns `target: "webview_dom"` plus the DOM click result. This route uses WebView geometry instead of native hit-testing so text editing overlays do not swallow WebView taps.
 
 ---
 
@@ -500,7 +500,7 @@ React Native response mirrors iOS or Android depending on the host platform.
 
 All WebView tools accept an optional `webview_id` parameter. If omitted, the first discovered WebView is used. Use `get_webviews` to list available WebViews and their IDs.
 
-`get_elements` is a native UI inventory and treats embedded web content as an opaque WebView. For DOM-level work, use `get_webviews`, then `get_dom_interactive`, `get_dom_forms`, `find_dom_text`, `web_click`, and `web_type`.
+On iOS and React Native iOS, `get_elements` includes visible interactive DOM controls inside discovered `WKWebView`s with `idSource: "dom"`, `source: "webview"`, `webviewId`, and `selector`. Those IDs work with `tap_element`, `tap_text`, `type_text`, and `clear_text`. For richer DOM-level work, use `get_webviews`, then `get_dom_interactive`, `get_dom_forms`, `find_dom_text`, `web_click`, and `web_type`.
 
 ### `get_webviews`
 List all web views in the current screen.

--- a/docs/wkwebview-support.md
+++ b/docs/wkwebview-support.md
@@ -4,7 +4,7 @@ Playwright-style DOM access for web views embedded in native iOS apps. Covers hy
 
 ## Problem
 
-`get_elements` and `get_view_tree` see WKWebView as a single opaque box. The agent knows a web view exists and its frame, but has zero visibility into what's rendered inside — no DOM nodes, no text content, no form fields, no links, no buttons. For apps that mix native and web content, the agent is blind on web screens.
+Historically, `get_elements` and `get_view_tree` saw WKWebView as a single opaque box. AppReveal now keeps the detailed DOM tools and also projects visible interactive DOM controls into `get_elements` on iOS and React Native iOS with `idSource: "dom"`. Agents can therefore discover common WebView form fields and buttons without a prior selector lookup, while still using the explicit `get_dom_*` and `web_*` tools for richer DOM inspection and interaction.
 
 ## How it works
 

--- a/iOS/Sources/AppReveal/Elements/ElementInventory.swift
+++ b/iOS/Sources/AppReveal/Elements/ElementInventory.swift
@@ -38,6 +38,13 @@ final class ElementInventory {
         return elements
     }
 
+    func listElementsIncludingWebContent(windowId: String? = nil) async -> [ElementInfo] {
+        var elements = listElements(windowId: windowId)
+        let domTargets = await WebViewBridge.shared.domElementTargets(windowId: windowId)
+        elements.append(contentsOf: domTargets.map(\.elementInfo))
+        return elements
+    }
+
     func findElement(byId id: String, windowId: String? = nil) -> UIView? {
         let windows = candidateWindows(windowId: windowId)
         for ref in windows {

--- a/iOS/Sources/AppReveal/Interaction/InteractionEngine.swift
+++ b/iOS/Sources/AppReveal/Interaction/InteractionEngine.swift
@@ -83,10 +83,23 @@ final class InteractionEngine {
 
         for ref in candidateWindows(windowId: windowId) {
             let window = ref.nativeWindow
+
+            // Full-screen WebView shells can be covered by UIKit text/editing overlay
+            // windows while an HTML input is focused. If the point is inside any known
+            // WKWebView, let DOM elementFromPoint handle it before native hit-testing.
+            if WebViewBridge.shared.clickElement(at: point, windowId: ref.id) {
+                return true
+            }
+
             let hitView = window.hitTest(point, with: nil)
 
-            if hitView.map({ findParent(of: $0, type: WKWebView.self) != nil }) == true,
-               WebViewBridge.shared.clickElement(at: point, windowId: ref.id) {
+            if isTextEditingOverlay(window: window, hitView: hitView),
+               WebViewBridge.shared.clickElement(at: point, windowId: windowId) {
+                return true
+            }
+
+            if let webView = findParent(of: hitView, type: WKWebView.self),
+               WebViewBridge.shared.clickElement(at: point, in: webView) {
                 return true
             }
 
@@ -183,6 +196,23 @@ final class InteractionEngine {
             current = v.superview
         }
         return nil
+    }
+
+    private func isTextEditingOverlay(window: UIWindow, hitView: UIView?) -> Bool {
+        var names = [String(describing: Swift.type(of: window)).lowercased()]
+        var current = hitView
+        var depth = 0
+        while let view = current, depth < 12 {
+            names.append(String(describing: Swift.type(of: view)).lowercased())
+            current = view.superview
+            depth += 1
+        }
+        return names.contains { name in
+            name.contains("texteffects") ||
+            name.contains("editingoverlay") ||
+            name.contains("inputset") ||
+            name.contains("keyboard")
+        }
     }
 
     private static func isSwiftUIHostingView(_ view: UIView) -> Bool {

--- a/iOS/Sources/AppReveal/MCPServer/MCPTools.swift
+++ b/iOS/Sources/AppReveal/MCPServer/MCPTools.swift
@@ -581,7 +581,8 @@ private func registerIOSBuiltInTools() {
         handler: { params in
             let windowId = params?["window_id"]?.stringValue
             let elements = ElementInventory.shared.listElements(windowId: windowId)
-            let list = elements.map { el in
+            let domTargets = await WebViewBridge.shared.domElementTargets(windowId: windowId)
+            var list = elements.map { el in
                 [
                     "id": el.id,
                     "type": el.type.rawValue,
@@ -607,6 +608,35 @@ private func registerIOSBuiltInTools() {
                     "idSource": el.idSource
                 ] as [String: Any]
             }
+            list.append(contentsOf: domTargets.map { target in
+                [
+                    "id": target.id,
+                    "type": target.type.rawValue,
+                    "label": target.label ?? "",
+                    "value": target.value ?? "",
+                    "enabled": target.enabled ? "true" : "false",
+                    "visible": target.frame.isEmpty ? "false" : "true",
+                    "tappable": target.actions.contains("tap") ? "true" : "false",
+                    "frame": "\(Int(target.frame.origin.x)),\(Int(target.frame.origin.y)),\(Int(target.frame.width)),\(Int(target.frame.height))",
+                    "safeAreaInsets": [
+                        "top": 0,
+                        "leading": 0,
+                        "bottom": 0,
+                        "trailing": 0
+                    ],
+                    "safeAreaLayoutGuideFrame": [
+                        "x": target.frame.origin.x,
+                        "y": target.frame.origin.y,
+                        "width": target.frame.width,
+                        "height": target.frame.height
+                    ],
+                    "actions": target.actions.joined(separator: ","),
+                    "idSource": "dom",
+                    "source": "webview",
+                    "webviewId": target.webViewId,
+                    "selector": target.selector
+                ] as [String: Any]
+            })
             return AnyCodable(["screenKey": ScreenResolver.shared.resolve().screenKey, "elements": list] as [String: Any])
         }
     ))
@@ -673,6 +703,16 @@ private func registerIOSBuiltInTools() {
                 try InteractionEngine.shared.tap(elementId: elementId, windowId: windowId)
                 return AnyCodable(["success": true, "element_id": elementId] as [String: Any])
             } catch {
+                if let target = await WebViewBridge.shared.findDOMElementTarget(id: elementId, windowId: windowId),
+                   let domResult = await WebViewBridge.shared.clickElementResult(target, windowId: windowId) {
+                    let success = (domResult["success"] as? Bool) ?? (domResult["error"] == nil)
+                    return AnyCodable([
+                        "success": success,
+                        "element_id": elementId,
+                        "target": "webview_dom",
+                        "dom": domResult
+                    ] as [String: Any])
+                }
                 return AnyCodable(["error": "\(error.localizedDescription). Try tap_text for visible text targeting, or get_elements to list available IDs."])
             }
         }
@@ -706,6 +746,38 @@ private func registerIOSBuiltInTools() {
             )
 
             guard result.isSuccess, let target = result.target else {
+                let domMatches = await WebViewBridge.shared.matchingDOMElementTargets(
+                    text: text,
+                    matchMode: matchMode,
+                    windowId: windowId
+                )
+                if !domMatches.isEmpty {
+                    if domMatches.count > 1 && occurrence >= domMatches.count {
+                        return AnyCodable([
+                            "error": "occurrence \(occurrence) out of range (found \(domMatches.count) DOM matches)",
+                            "candidates": domMatches.map { $0.label ?? $0.id },
+                            "hint": "Use occurrence parameter (0-based) to select a specific match"
+                        ] as [String: Any])
+                    }
+                    if domMatches.count > 1 && occurrence < 0 {
+                        return AnyCodable([
+                            "error": "Ambiguous: \(domMatches.count) DOM matches found. Use occurrence (0-based) to disambiguate.",
+                            "candidates": domMatches.map { $0.label ?? $0.id },
+                            "hint": "Use occurrence parameter (0-based) to select a specific match"
+                        ] as [String: Any])
+                    }
+                    let index = domMatches.count == 1 ? 0 : occurrence
+                    if let domResult = await WebViewBridge.shared.clickElementResult(domMatches[index], windowId: windowId) {
+                        let success = (domResult["success"] as? Bool) ?? (domResult["error"] == nil)
+                        return AnyCodable([
+                            "success": success,
+                            "text": text,
+                            "target": "webview_dom",
+                            "dom": domResult
+                        ] as [String: Any])
+                    }
+                }
+
                 var response: [String: Any] = ["error": result.error ?? "Unknown error"]
                 if let candidates = result.candidates {
                     response["candidates"] = candidates
@@ -753,6 +825,16 @@ private func registerIOSBuiltInTools() {
             }
             let windowId = params?["window_id"]?.stringValue
             let point = CGPoint(x: x, y: y)
+            if let domResult = await WebViewBridge.shared.clickElementResult(at: point, windowId: windowId) {
+                let success = (domResult["success"] as? Bool) ?? (domResult["error"] == nil)
+                return AnyCodable([
+                    "x": x,
+                    "y": y,
+                    "success": success,
+                    "target": "webview_dom",
+                    "dom": domResult
+                ] as [String: Any])
+            }
             let activated = InteractionEngine.shared.tap(point: point, windowId: windowId)
             var result: [String: Any] = ["x": x, "y": y, "success": activated]
             if !activated {
@@ -798,6 +880,15 @@ private func registerIOSBuiltInTools() {
                 try InteractionEngine.shared.type(text: text, elementId: params?["element_id"]?.stringValue, windowId: windowId)
                 return AnyCodable(["success": true, "text": text] as [String: Any])
             } catch {
+                if let elementId = params?["element_id"]?.stringValue,
+                   let target = await WebViewBridge.shared.findDOMElementTarget(id: elementId, windowId: windowId),
+                   WebViewBridge.shared.typeText(text, in: target, clear: false, windowId: windowId) {
+                    return AnyCodable([
+                        "success": true,
+                        "text": text,
+                        "target": "webview_dom"
+                    ] as [String: Any])
+                }
                 return AnyCodable(["error": error.localizedDescription])
             }
         }
@@ -825,6 +916,13 @@ private func registerIOSBuiltInTools() {
                 try InteractionEngine.shared.clear(elementId: elementId, windowId: windowId)
                 return AnyCodable(["success": true] as [String: Any])
             } catch {
+                if let target = await WebViewBridge.shared.findDOMElementTarget(id: elementId, windowId: windowId),
+                   WebViewBridge.shared.clearText(in: target, windowId: windowId) {
+                    return AnyCodable([
+                        "success": true,
+                        "target": "webview_dom"
+                    ] as [String: Any])
+                }
                 return AnyCodable(["error": error.localizedDescription])
             }
         }
@@ -972,7 +1070,26 @@ private func registerIOSBuiltInTools() {
         handler: { params in
             let maxDepth = params?["max_depth"]?.intValue ?? 50
             let windowId = params?["window_id"]?.stringValue
-            let tree = ElementInventory.shared.dumpViewTree(maxDepth: maxDepth, windowId: windowId)
+            var tree = ElementInventory.shared.dumpViewTree(maxDepth: maxDepth, windowId: windowId)
+            let domTargets = await WebViewBridge.shared.domElementTargets(windowId: windowId)
+            tree.append(contentsOf: domTargets.map { target in
+                [
+                    "class": "DOMElement",
+                    "framework": "webview",
+                    "accessibilityId": target.id,
+                    "accessibilityLabel": target.label ?? "",
+                    "accessibilityValue": target.value ?? "",
+                    "webviewId": target.webViewId,
+                    "selector": target.selector,
+                    "elementType": target.type.rawValue,
+                    "actions": target.actions,
+                    "frame": "\(Int(target.frame.origin.x)),\(Int(target.frame.origin.y)),\(Int(target.frame.width)),\(Int(target.frame.height))",
+                    "hidden": target.frame.isEmpty,
+                    "alpha": 1,
+                    "userInteraction": target.enabled,
+                    "depth": 1
+                ] as [String: Any]
+            })
             return AnyCodable(["views": tree, "count": tree.count] as [String: Any])
         }
     ))

--- a/iOS/Sources/AppReveal/WebView/DOMSerializer.swift
+++ b/iOS/Sources/AppReveal/WebView/DOMSerializer.swift
@@ -1,10 +1,200 @@
 // JavaScript strings for DOM operations, injected into WKWebView
 
+import CoreGraphics
 import Foundation
 
 #if DEBUG
 
 enum DOMSerializer {
+
+    // MARK: - Native element inventory projection
+
+    static func elementInventoryJS() -> String {
+        return """
+        (function() {
+            var selectors = 'a[href],button,input,textarea,select,label,[role="button"],[role="link"],[onclick],[tabindex]:not([tabindex="-1"])';
+            var nodes = Array.prototype.slice.call(document.querySelectorAll(selectors));
+            var viewportWidth = Math.max(1, window.innerWidth || document.documentElement.clientWidth || 1);
+            var viewportHeight = Math.max(1, window.innerHeight || document.documentElement.clientHeight || 1);
+            var results = [];
+            var seenIds = Object.create(null);
+
+            function normalizeId(value) {
+                var normalized = String(value || '').trim().toLowerCase()
+                    .replace(/\\s+/g, '_')
+                    .replace(/[^a-z0-9_.-]/g, '_')
+                    .replace(/_+/g, '_')
+                    .replace(/^[_\\.-]+|[_\\.-]+$/g, '');
+                return normalized.substring(0, 60);
+            }
+
+            function cssEscape(value) {
+                if (window.CSS && typeof window.CSS.escape === 'function') {
+                    return window.CSS.escape(value);
+                }
+                return String(value).replace(/([^a-zA-Z0-9_-])/g, '\\\\$1');
+            }
+
+            function attrValue(value) {
+                return String(value).replace(/\\\\/g, '\\\\\\\\').replace(/"/g, '\\\\"');
+            }
+
+            function selectorFor(node) {
+                var testId = node.getAttribute('data-testid');
+                if (testId) return '[data-testid="' + attrValue(testId) + '"]';
+                var dataTest = node.getAttribute('data-test');
+                if (dataTest) return '[data-test="' + attrValue(dataTest) + '"]';
+                var dataCy = node.getAttribute('data-cy');
+                if (dataCy) return '[data-cy="' + attrValue(dataCy) + '"]';
+                if (node.id) return '#' + cssEscape(node.id);
+                if (node.name) return node.tagName.toLowerCase() + '[name="' + attrValue(node.name) + '"]';
+                var path = [];
+                var current = node;
+                while (current && current !== document.body && current.nodeType === Node.ELEMENT_NODE) {
+                    var tag = current.tagName.toLowerCase();
+                    var parent = current.parentElement;
+                    if (parent) {
+                        var siblings = Array.prototype.slice.call(parent.children)
+                            .filter(function(child) { return child.tagName === current.tagName; });
+                        if (siblings.length > 1) {
+                            tag += ':nth-of-type(' + (siblings.indexOf(current) + 1) + ')';
+                        }
+                    }
+                    path.unshift(tag);
+                    current = parent;
+                }
+                return path.join(' > ');
+            }
+
+            function textFor(node) {
+                var labelText = labelTextFor(node);
+                if (node.tagName === 'INPUT' || node.tagName === 'TEXTAREA') {
+                    return node.getAttribute('aria-label') ||
+                        labelText ||
+                        node.getAttribute('placeholder') ||
+                        node.value ||
+                        node.name ||
+                        node.id ||
+                        '';
+                }
+                return node.getAttribute('aria-label') ||
+                    labelText ||
+                    (node.innerText || node.textContent || '').trim() ||
+                    node.value ||
+                    node.getAttribute('title') ||
+                    node.name ||
+                    node.id ||
+                    '';
+            }
+
+            function labelTextFor(node) {
+                if (node.labels && node.labels.length) {
+                    return Array.from(node.labels).map(function(label) {
+                        return (label.innerText || label.textContent || '').trim();
+                    }).filter(Boolean).join(' ');
+                }
+                if (node.id) {
+                    var explicit = document.querySelector('label[for="' + attrValue(node.id) + '"]');
+                    if (explicit) return (explicit.innerText || explicit.textContent || '').trim();
+                }
+                var parentLabel = node.closest('label');
+                return parentLabel ? (parentLabel.innerText || parentLabel.textContent || '').trim() : '';
+            }
+
+            function typeFor(node) {
+                var tag = node.tagName.toLowerCase();
+                var role = (node.getAttribute('role') || '').toLowerCase();
+                var inputType = (node.getAttribute('type') || '').toLowerCase();
+                if (tag === 'input' && (inputType === 'checkbox' || inputType === 'radio')) return 'toggle';
+                if (tag === 'input' || tag === 'textarea') return 'textField';
+                if (tag === 'select') return 'picker';
+                if (tag === 'button' || tag === 'a' || tag === 'label' || role === 'button' || role === 'link' || node.onclick) return 'button';
+                return 'other';
+            }
+
+            function actionsFor(type) {
+                var actions = ['tap'];
+                if (type === 'textField') {
+                    actions.push('type');
+                    actions.push('clear');
+                }
+                if (type === 'picker') actions.push('select');
+                if (type === 'toggle') actions.push('toggle');
+                return actions;
+            }
+
+            function stableRawId(node, index, label) {
+                var source = node.getAttribute('data-testid') ||
+                    node.getAttribute('data-test') ||
+                    node.getAttribute('data-cy') ||
+                    node.id ||
+                    node.name ||
+                    node.getAttribute('aria-label') ||
+                    node.getAttribute('placeholder') ||
+                    label ||
+                    (node.tagName.toLowerCase() + '_' + index);
+                var raw = normalizeId(source) || ('element_' + index);
+                var count = seenIds[raw] || 0;
+                seenIds[raw] = count + 1;
+                return count === 0 ? raw : raw + '_' + count;
+            }
+
+            for (var i = 0; i < nodes.length; i++) {
+                var node = nodes[i];
+                var rect = node.getBoundingClientRect();
+                var style = window.getComputedStyle(node);
+                var visible = rect.width > 0 &&
+                    rect.height > 0 &&
+                    rect.right > 0 &&
+                    rect.bottom > 0 &&
+                    rect.left < viewportWidth &&
+                    rect.top < viewportHeight &&
+                    style.display !== 'none' &&
+                    style.visibility !== 'hidden' &&
+                    style.opacity !== '0';
+                if (!visible) continue;
+
+                var type = typeFor(node);
+                var label = textFor(node);
+                var labelText = labelTextFor(node);
+                var rawId = stableRawId(node, i, label);
+                var disabled = !!node.disabled || node.getAttribute('aria-disabled') === 'true';
+                var value = '';
+                if ((node.tagName === 'INPUT' || node.tagName === 'TEXTAREA' || node.tagName === 'SELECT') &&
+                    (node.getAttribute('type') || '').toLowerCase() !== 'password') {
+                    value = node.value || '';
+                }
+
+                results.push({
+                    rawId: rawId,
+                    selector: selectorFor(node),
+                    type: type,
+                    label: label.substring(0, 200),
+                    value: String(value).substring(0, 200),
+                    labelText: labelText.substring(0, 200),
+                    inputType: (node.getAttribute('type') || '').toLowerCase(),
+                    enabled: !disabled,
+                    visible: visible,
+                    tappable: true,
+                    actions: actionsFor(type),
+                    rect: {
+                        x: Math.round(rect.x),
+                        y: Math.round(rect.y),
+                        w: Math.round(rect.width),
+                        h: Math.round(rect.height)
+                    },
+                    tag: node.tagName.toLowerCase()
+                });
+            }
+
+            return JSON.stringify({
+                viewport: {width: viewportWidth, height: viewportHeight},
+                elements: results,
+                count: results.length
+            });
+        })()
+        """
+    }
 
     // MARK: - DOM Tree
 
@@ -73,30 +263,64 @@ enum DOMSerializer {
                 var node = nodes[i];
                 var rect = node.getBoundingClientRect();
                 if (rect.width === 0 && rect.height === 0) continue;
+                var style = window.getComputedStyle(node);
+                if (style.display === 'none' || style.visibility === 'hidden') continue;
+                var testId = node.getAttribute('data-testid') || node.getAttribute('data-test') || node.getAttribute('data-cy');
+                var ariaLabel = node.getAttribute('aria-label') || '';
+                var text = (node.innerText || node.textContent || '').trim();
+                var tag = node.tagName.toLowerCase();
+                var role = node.getAttribute('role') || '';
+                var inputType = (node.getAttribute('type') || '').toLowerCase();
+                var labelText = labelTextFor(node);
                 var el = {
-                    tag: node.tagName.toLowerCase(),
+                    index: i,
+                    tag: tag,
+                    role: role,
                     rect: {x:Math.round(rect.x),y:Math.round(rect.y),w:Math.round(rect.width),h:Math.round(rect.height)},
-                    selector: genSelector(node)
+                    selector: genSelector(node),
+                    label: (ariaLabel || labelText || text || node.placeholder || node.value || node.title || node.name || node.id || testId || '').substring(0, 200),
+                    enabled: !node.disabled,
+                    visible: true,
+                    tappable: isTappable(node, tag, role, inputType),
+                    actions: actionsFor(node, tag, role, inputType)
                 };
                 if (node.id) el.id = node.id;
                 if (node.name) el.name = node.name;
-                if (node.type) el.type = node.type;
+                if (node.type) el.inputType = node.type;
                 if (node.placeholder) el.placeholder = node.placeholder;
                 if (node.value) el.value = node.value.substring(0, 200);
-                var text = node.textContent.trim();
                 if (text) el.text = text.substring(0, 100);
-                var testId = node.getAttribute('data-testid') || node.getAttribute('data-test') || node.getAttribute('data-cy');
+                if (labelText) el.labelText = labelText.substring(0, 100);
                 if (testId) el.testId = testId;
-                if (node.getAttribute('aria-label')) el.ariaLabel = node.getAttribute('aria-label');
+                if (ariaLabel) el.ariaLabel = ariaLabel;
                 if (node.disabled) el.disabled = true;
                 if (node.checked !== undefined) el.checked = node.checked;
                 if (node.href) el.href = node.href;
                 results.push(el);
             }
+            function cssEscape(value) {
+                if (window.CSS && typeof window.CSS.escape === 'function') return window.CSS.escape(value);
+                return String(value).replace(/["\\\\]/g, '\\\\$&').replace(/[^a-zA-Z0-9_-]/g, '\\\\$&');
+            }
+            function labelTextFor(el) {
+                if (el.labels && el.labels.length) {
+                    return Array.from(el.labels).map(function(label) {
+                        return (label.innerText || label.textContent || '').trim();
+                    }).filter(Boolean).join(' ');
+                }
+                if (el.id) {
+                    var explicit = document.querySelector('label[for="' + cssEscape(el.id) + '"]');
+                    if (explicit) return (explicit.innerText || explicit.textContent || '').trim();
+                }
+                var parentLabel = el.closest('label');
+                return parentLabel ? (parentLabel.innerText || parentLabel.textContent || '').trim() : '';
+            }
             function genSelector(el) {
-                if (el.getAttribute('data-testid')) return '[data-testid=\"' + el.getAttribute('data-testid') + '\"]';
-                if (el.id) return '#' + el.id;
-                if (el.name) return el.tagName.toLowerCase() + '[name=\"' + el.name + '\"]';
+                if (el.getAttribute('data-testid')) return '[data-testid=\"' + cssEscape(el.getAttribute('data-testid')) + '\"]';
+                if (el.getAttribute('data-test')) return '[data-test=\"' + cssEscape(el.getAttribute('data-test')) + '\"]';
+                if (el.getAttribute('data-cy')) return '[data-cy=\"' + cssEscape(el.getAttribute('data-cy')) + '\"]';
+                if (el.id) return '#' + cssEscape(el.id);
+                if (el.name) return el.tagName.toLowerCase() + '[name=\"' + cssEscape(el.name) + '\"]';
                 var path = [];
                 while (el && el !== document.body) {
                     var tag = el.tagName.toLowerCase();
@@ -113,7 +337,34 @@ enum DOMSerializer {
                 }
                 return path.join(' > ');
             }
-            return JSON.stringify({elements: results, count: results.length});
+            function isTappable(node, tag, role, inputType) {
+                if (node.disabled) return false;
+                return tag === 'button' || tag === 'a' || tag === 'select' || tag === 'label' ||
+                    role === 'button' || role === 'link' || !!node.onclick ||
+                    inputType === 'button' || inputType === 'submit' || inputType === 'reset' ||
+                    inputType === 'checkbox' || inputType === 'radio' ||
+                    node.tabIndex >= 0;
+            }
+            function actionsFor(node, tag, role, inputType) {
+                var actions = [];
+                if (isTappable(node, tag, role, inputType)) actions.push('tap');
+                if (tag === 'textarea' || (tag === 'input' && !['button','submit','reset','checkbox','radio','hidden','file'].includes(inputType))) {
+                    actions.push('type');
+                    actions.push('clear');
+                }
+                if (tag === 'select') actions.push('select');
+                return actions;
+            }
+            return JSON.stringify({
+                elements: results,
+                count: results.length,
+                viewport: {
+                    width: Math.max(1, window.innerWidth || document.documentElement.clientWidth || 1),
+                    height: Math.max(1, window.innerHeight || document.documentElement.clientHeight || 1)
+                },
+                title: document.title || '',
+                url: location.href
+            });
         })()
         """
     }
@@ -209,8 +460,76 @@ enum DOMSerializer {
         (function() {
             var el = document.querySelector('\(escapeJS(selector))');
             if (!el) return JSON.stringify({error:'Element not found: \(escapeJS(selector))'});
+            var rect = el.getBoundingClientRect();
+            var x = rect.left + rect.width / 2;
+            var y = rect.top + rect.height / 2;
+            if (typeof el.focus === 'function') {
+                try { el.focus({preventScroll:true}); } catch (_) { el.focus(); }
+            }
+            var eventInit = {bubbles:true, cancelable:true, view:window, clientX:x, clientY:y};
+            if (typeof PointerEvent !== 'undefined') {
+                el.dispatchEvent(new PointerEvent('pointerdown', Object.assign({pointerId:1, pointerType:'mouse', isPrimary:true}, eventInit)));
+                el.dispatchEvent(new PointerEvent('pointerup', Object.assign({pointerId:1, pointerType:'mouse', isPrimary:true}, eventInit)));
+            }
+            el.dispatchEvent(new MouseEvent('mousedown', eventInit));
+            el.dispatchEvent(new MouseEvent('mouseup', eventInit));
             el.click();
-            return JSON.stringify({success:true, tag:el.tagName.toLowerCase(), text:el.textContent.trim().substring(0,100)});
+            if (el.checked !== undefined) {
+                el.dispatchEvent(new Event('input', {bubbles:true}));
+                el.dispatchEvent(new Event('change', {bubbles:true}));
+            }
+            return JSON.stringify({
+                success:true,
+                tag:el.tagName.toLowerCase(),
+                text:(el.innerText || el.textContent || el.value || '').trim().substring(0,100),
+                checked: el.checked,
+                value: el.value
+            });
+        })()
+        """
+    }
+
+    static func pointClickJS(localPoint: CGPoint, webViewSize: CGSize) -> String {
+        return """
+        (() => {
+          const viewWidth = Math.max(1, window.innerWidth || document.documentElement.clientWidth || \(webViewSize.width));
+          const viewHeight = Math.max(1, window.innerHeight || document.documentElement.clientHeight || \(webViewSize.height));
+          const x = \(localPoint.x) * viewWidth / Math.max(1, \(webViewSize.width));
+          const y = \(localPoint.y) * viewHeight / Math.max(1, \(webViewSize.height));
+          const element = document.elementFromPoint(x, y);
+          if (!element) {
+            return JSON.stringify({ success: false, error: "no_dom_element", x, y });
+          }
+          const target = element.closest('button,a,input,textarea,select,label,[role="button"],[role="link"],[onclick]') || element;
+          if (typeof target.focus === 'function') {
+            try { target.focus({ preventScroll: true }); } catch (_) { target.focus(); }
+          }
+          const eventInit = { bubbles: true, cancelable: true, view: window, clientX: x, clientY: y };
+          if (typeof PointerEvent !== 'undefined') {
+            target.dispatchEvent(new PointerEvent('pointerdown', Object.assign({ pointerId: 1, pointerType: 'mouse', isPrimary: true }, eventInit)));
+            target.dispatchEvent(new PointerEvent('pointerup', Object.assign({ pointerId: 1, pointerType: 'mouse', isPrimary: true }, eventInit)));
+          }
+          target.dispatchEvent(new MouseEvent('mousedown', eventInit));
+          target.dispatchEvent(new MouseEvent('mouseup', eventInit));
+          if (typeof target.click === 'function') {
+            target.click();
+          } else {
+            target.dispatchEvent(new MouseEvent('click', eventInit));
+          }
+          if (target.checked !== undefined) {
+            target.dispatchEvent(new Event('input', { bubbles: true }));
+            target.dispatchEvent(new Event('change', { bubbles: true }));
+          }
+          return JSON.stringify({
+            success: true,
+            tag: target.tagName.toLowerCase(),
+            id: target.id || null,
+            text: (target.innerText || target.textContent || target.value || '').trim().slice(0, 120),
+            checked: target.checked,
+            value: target.value,
+            x,
+            y
+          });
         })()
         """
     }

--- a/iOS/Sources/AppReveal/WebView/WebViewBridge.swift
+++ b/iOS/Sources/AppReveal/WebView/WebViewBridge.swift
@@ -24,6 +24,53 @@ import UIKit
 import WebKit
 
 @MainActor
+struct DOMElementTarget {
+    let id: String
+    let webViewId: String
+    let selector: String
+    let type: ElementType
+    let label: String?
+    let value: String?
+    let enabled: Bool
+    let frame: CGRect
+    let actions: [String]
+    let textCandidates: [String]
+
+    var centerPoint: CGPoint {
+        CGPoint(x: frame.midX, y: frame.midY)
+    }
+
+    var elementInfo: ElementInfo {
+        ElementInfo(
+            id: id,
+            type: type,
+            label: label,
+            value: value,
+            enabled: enabled,
+            visible: frame.width > 0 && frame.height > 0,
+            tappable: actions.contains("tap"),
+            frame: ElementInventory.makeFrame(frame),
+            safeAreaInsets: ElementInfo.ElementInsets(top: 0, leading: 0, bottom: 0, trailing: 0),
+            safeAreaLayoutGuideFrame: ElementInventory.makeFrame(frame),
+            containerId: webViewId,
+            actions: actions,
+            idSource: "dom"
+        )
+    }
+
+    func matches(text query: String, matchMode: String) -> Bool {
+        textCandidates.contains { candidate in
+            switch matchMode {
+            case "contains":
+                return candidate.localizedCaseInsensitiveContains(query)
+            default:
+                return candidate == query
+            }
+        }
+    }
+}
+
+@MainActor
 final class WebViewBridge {
 
     static let shared = WebViewBridge()
@@ -69,39 +116,16 @@ final class WebViewBridge {
             }) else {
             return false
         }
+        return clickElement(at: windowPoint, in: webView)
+    }
 
+    @discardableResult
+    func clickElement(at windowPoint: CGPoint, in webView: WKWebView) -> Bool {
+        guard webView.convert(webView.bounds, to: nil).contains(windowPoint) else {
+            return false
+        }
         let localPoint = webView.convert(windowPoint, from: nil)
-        let js = """
-        (() => {
-          const viewWidth = Math.max(1, window.innerWidth || document.documentElement.clientWidth || \(webView.bounds.width));
-          const viewHeight = Math.max(1, window.innerHeight || document.documentElement.clientHeight || \(webView.bounds.height));
-          const x = \(localPoint.x) * viewWidth / Math.max(1, \(webView.bounds.width));
-          const y = \(localPoint.y) * viewHeight / Math.max(1, \(webView.bounds.height));
-          const element = document.elementFromPoint(x, y);
-          if (!element) {
-            return JSON.stringify({ success: false, error: "no_dom_element", x, y });
-          }
-          const target = element.closest('button,a,input,textarea,select,label,[role="button"],[onclick]') || element;
-          if (typeof target.focus === 'function') {
-            try { target.focus({ preventScroll: true }); } catch (_) { target.focus(); }
-          }
-          const eventInit = { bubbles: true, cancelable: true, view: window, clientX: x, clientY: y };
-          for (const type of ['pointerdown', 'mousedown', 'pointerup', 'mouseup']) {
-            target.dispatchEvent(new MouseEvent(type, eventInit));
-          }
-          if (typeof target.click === 'function') {
-            target.click();
-          } else {
-            target.dispatchEvent(new MouseEvent('click', eventInit));
-          }
-          return JSON.stringify({
-            success: true,
-            tag: target.tagName,
-            id: target.id || null,
-            text: (target.innerText || target.value || '').slice(0, 120)
-          });
-        })()
-        """
+        let js = DOMSerializer.pointClickJS(localPoint: localPoint, webViewSize: webView.bounds.size)
 
         webView.evaluateJavaScript(js) { _, error in
             if let error {
@@ -109,6 +133,199 @@ final class WebViewBridge {
             }
         }
         return true
+    }
+
+    func clickElementResult(at windowPoint: CGPoint, windowId: String? = nil) async -> [String: Any]? {
+        guard let webView = findWebViews(windowId: windowId)
+            .map(\.webView)
+            .first(where: { webView in
+                webView.convert(webView.bounds, to: nil).contains(windowPoint)
+            }) else {
+            return nil
+        }
+
+        let localPoint = webView.convert(windowPoint, from: nil)
+        let js = DOMSerializer.pointClickJS(localPoint: localPoint, webViewSize: webView.bounds.size)
+        do {
+            let result = try await evaluate(js: js, in: webView)
+            return Self.jsonDictionary(from: result)
+        } catch {
+            print("[AppReveal] WebView tap_point DOM click failed: \(error.localizedDescription)")
+            return [
+                "success": false,
+                "error": error.localizedDescription
+            ]
+        }
+    }
+
+    @discardableResult
+    func clickElement(selector: String, webViewId: String?, windowId: String? = nil) -> Bool {
+        guard let webView = resolveWebView(id: webViewId, windowId: windowId) else {
+            return false
+        }
+        webView.evaluateJavaScript(DOMSerializer.clickJS(selector: selector)) { _, error in
+            if let error {
+                print("[AppReveal] WebView DOM click failed: \(error.localizedDescription)")
+            }
+        }
+        return true
+    }
+
+    @discardableResult
+    func clickElement(_ target: DOMElementTarget, windowId: String? = nil) -> Bool {
+        clickElement(selector: target.selector, webViewId: target.webViewId, windowId: windowId)
+    }
+
+    func clickElementResult(_ target: DOMElementTarget, windowId: String? = nil) async -> [String: Any]? {
+        guard let webView = resolveWebView(id: target.webViewId, windowId: windowId) else {
+            return nil
+        }
+        do {
+            let result = try await evaluate(js: DOMSerializer.clickJS(selector: target.selector), in: webView)
+            return Self.jsonDictionary(from: result)
+        } catch {
+            print("[AppReveal] WebView DOM click failed: \(error.localizedDescription)")
+            return [
+                "success": false,
+                "error": error.localizedDescription
+            ]
+        }
+    }
+
+    @discardableResult
+    func typeText(_ text: String, in target: DOMElementTarget, clear: Bool, windowId: String? = nil) -> Bool {
+        guard target.actions.contains("type"),
+              let webView = resolveWebView(id: target.webViewId, windowId: windowId) else {
+            return false
+        }
+        webView.evaluateJavaScript(DOMSerializer.typeJS(selector: target.selector, text: text, clear: clear)) { _, error in
+            if let error {
+                print("[AppReveal] WebView DOM type failed: \(error.localizedDescription)")
+            }
+        }
+        return true
+    }
+
+    @discardableResult
+    func clearText(in target: DOMElementTarget, windowId: String? = nil) -> Bool {
+        typeText("", in: target, clear: true, windowId: windowId)
+    }
+
+    func domElementTargets(windowId: String? = nil) async -> [DOMElementTarget] {
+        var targets: [DOMElementTarget] = []
+        var seenIds: [String: Int] = [:]
+
+        for item in findWebViews(windowId: windowId) {
+            guard let payload = try? await interactivePayload(for: item.webView),
+                  let rawElements = payload["elements"] as? [[String: Any]] else {
+                continue
+            }
+
+            let viewport = payload["viewport"] as? [String: Any]
+            let viewportWidth = Self.cgFloat(viewport?["w"])
+                ?? Self.cgFloat(viewport?["width"])
+                ?? max(item.webView.bounds.width, 1)
+            let viewportHeight = Self.cgFloat(viewport?["h"])
+                ?? Self.cgFloat(viewport?["height"])
+                ?? max(item.webView.bounds.height, 1)
+            let scaleX = item.webView.bounds.width / max(viewportWidth, 1)
+            let scaleY = item.webView.bounds.height / max(viewportHeight, 1)
+            let webViewFrame = item.webView.convert(item.webView.bounds, to: nil)
+
+            for (index, raw) in rawElements.enumerated() {
+                guard let selector = Self.string(raw["selector"]),
+                      let rect = raw["rect"] as? [String: Any],
+                      let x = Self.cgFloat(rect["x"]),
+                      let y = Self.cgFloat(rect["y"]),
+                      let width = Self.cgFloat(rect["w"]),
+                      let height = Self.cgFloat(rect["h"]) else {
+                    continue
+                }
+
+                let frame = CGRect(
+                    x: webViewFrame.origin.x + (x * scaleX),
+                    y: webViewFrame.origin.y + (y * scaleY),
+                    width: width * scaleX,
+                    height: height * scaleY
+                )
+                guard frame.width > 0 || frame.height > 0 else { continue }
+
+                let tag = Self.string(raw["tag"])?.lowercased() ?? "element"
+                let inputType = Self.string(raw["inputType"])?.lowercased()
+                let label = Self.firstNonEmpty([
+                    Self.string(raw["label"]),
+                    Self.string(raw["labelText"]),
+                    Self.string(raw["ariaLabel"]),
+                    Self.string(raw["text"]),
+                    Self.string(raw["placeholder"]),
+                    Self.string(raw["name"]),
+                    Self.string(raw["id"]),
+                    Self.string(raw["testId"])
+                ])
+                let value = Self.string(raw["value"])
+                let enabledValue = raw["enabled"] as? Bool
+                let disabled = (raw["disabled"] as? Bool) == true || enabledValue == false
+                let type = Self.elementType(rawType: Self.string(raw["type"]), tag: tag, inputType: inputType)
+                let actions = Self.actions(for: type, enabled: !disabled)
+                let rawId = Self.firstNonEmpty([
+                    Self.string(raw["rawId"]),
+                    Self.string(raw["testId"]),
+                    Self.string(raw["id"]),
+                    Self.string(raw["name"]).map { "\(tag)_\($0)" },
+                    Self.string(raw["ariaLabel"]),
+                    Self.string(raw["labelText"]),
+                    Self.string(raw["label"]),
+                    Self.string(raw["placeholder"]),
+                    Self.string(raw["text"]),
+                    "\(tag)_\(index)"
+                ]) ?? "\(tag)_\(index)"
+                let id = Self.deduplicatedId(
+                    "web.\(Self.normalizeIdComponent(item.id)).\(Self.normalizeIdComponent(rawId))",
+                    seenIds: &seenIds
+                )
+                let textCandidates = [
+                    label,
+                    Self.string(raw["labelText"]),
+                    Self.string(raw["label"]),
+                    Self.string(raw["text"]),
+                    Self.string(raw["ariaLabel"]),
+                    Self.string(raw["placeholder"]),
+                    Self.string(raw["value"]),
+                    Self.string(raw["name"]),
+                    Self.string(raw["id"]),
+                    Self.string(raw["testId"])
+                ].compactMap { $0 }.filter { !$0.isEmpty }
+
+                targets.append(
+                    DOMElementTarget(
+                        id: id,
+                        webViewId: item.id,
+                        selector: selector,
+                        type: type,
+                        label: label,
+                        value: value,
+                        enabled: !disabled,
+                        frame: frame,
+                        actions: actions,
+                        textCandidates: textCandidates
+                    )
+                )
+            }
+        }
+
+        return targets
+    }
+
+    func findDOMElementTarget(id: String, windowId: String? = nil) async -> DOMElementTarget? {
+        await domElementTargets(windowId: windowId).first { $0.id == id }
+    }
+
+    func matchingDOMElementTargets(
+        text: String,
+        matchMode: String = "exact",
+        windowId: String? = nil
+    ) async -> [DOMElementTarget] {
+        await domElementTargets(windowId: windowId).filter { $0.matches(text: text, matchMode: matchMode) }
     }
 
     // MARK: - Metadata
@@ -135,13 +352,106 @@ final class WebViewBridge {
             throw WebViewError.notFound(webViewId ?? "default")
         }
 
+        return try await evaluate(js: js, in: webView)
+    }
+
+    private func evaluate(js: String, in webView: WKWebView) async throws -> String {
         let result = try await webView.evaluateJavaScript(js)
         if let string = result as? String {
             return string
         }
-        // For non-string results, convert to JSON
+        guard let result else {
+            return "null"
+        }
         let data = try JSONSerialization.data(withJSONObject: result, options: [])
         return String(data: data, encoding: .utf8) ?? "null"
+    }
+
+    private func interactivePayload(for webView: WKWebView) async throws -> [String: Any] {
+        let json = try await evaluate(js: DOMSerializer.elementInventoryJS(), in: webView)
+        return Self.jsonDictionary(from: json) ?? [:]
+    }
+
+    private static func elementType(rawType: String?, tag: String, inputType: String?) -> ElementType {
+        if let rawType, let type = ElementType(rawValue: rawType) {
+            return type
+        }
+        switch tag {
+        case "button", "a":
+            return .button
+        case "textarea":
+            return .textField
+        case "select":
+            return .picker
+        case "input":
+            switch inputType {
+            case "checkbox", "radio":
+                return .toggle
+            case "button", "submit", "reset":
+                return .button
+            default:
+                return .textField
+            }
+        default:
+            return .other
+        }
+    }
+
+    private static func actions(for type: ElementType, enabled: Bool) -> [String] {
+        guard enabled else { return [] }
+        switch type {
+        case .textField:
+            return ["tap", "type", "clear"]
+        case .picker:
+            return ["tap", "select"]
+        case .toggle:
+            return ["tap", "toggle"]
+        default:
+            return ["tap"]
+        }
+    }
+
+    private static func firstNonEmpty(_ values: [String?]) -> String? {
+        values.compactMap { value in
+            let trimmed = value?.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmed?.isEmpty == false ? trimmed : nil
+        }.first
+    }
+
+    private static func string(_ value: Any?) -> String? {
+        if let string = value as? String { return string }
+        if let number = value as? NSNumber { return number.stringValue }
+        return nil
+    }
+
+    private static func cgFloat(_ value: Any?) -> CGFloat? {
+        if let number = value as? NSNumber { return CGFloat(truncating: number) }
+        if let double = value as? Double { return CGFloat(double) }
+        if let string = value as? String, let double = Double(string) { return CGFloat(double) }
+        return nil
+    }
+
+    private static func jsonDictionary(from json: String) -> [String: Any]? {
+        guard let data = json.data(using: .utf8) else { return nil }
+        return try? JSONSerialization.jsonObject(with: data) as? [String: Any]
+    }
+
+    private static func normalizeIdComponent(_ value: String) -> String {
+        var normalized = value.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        normalized = normalized.replacingOccurrences(
+            of: "\\s+", with: "_", options: .regularExpression
+        )
+        normalized = normalized.replacingOccurrences(
+            of: "[^a-z0-9_.-]", with: "", options: .regularExpression
+        )
+        normalized = normalized.trimmingCharacters(in: CharacterSet(charactersIn: "._-"))
+        return normalized.isEmpty ? "element" : String(normalized.prefix(80))
+    }
+
+    private static func deduplicatedId(_ id: String, seenIds: inout [String: Int]) -> String {
+        let count = seenIds[id, default: 0]
+        seenIds[id] = count + 1
+        return count == 0 ? id : "\(id)_\(count)"
     }
 }
 

--- a/iOS/Tests/AppRevealTests/DOMSerializerTests.swift
+++ b/iOS/Tests/AppRevealTests/DOMSerializerTests.swift
@@ -1,0 +1,31 @@
+import CoreGraphics
+import XCTest
+@testable import AppReveal
+
+#if DEBUG
+
+final class DOMSerializerTests: XCTestCase {
+    func testElementInventoryScriptProjectsDOMControlsForNativeInventory() {
+        let script = DOMSerializer.elementInventoryJS()
+
+        XCTAssertTrue(script.contains("data-testid"))
+        XCTAssertTrue(script.contains("viewport"))
+        XCTAssertTrue(script.contains("rawId"))
+        XCTAssertTrue(script.contains("textField"))
+        XCTAssertTrue(script.contains("toggle"))
+    }
+
+    func testPointClickScriptUsesDOMElementFromPointAndPointerEvents() {
+        let script = DOMSerializer.pointClickJS(
+            localPoint: CGPoint(x: 20, y: 30),
+            webViewSize: CGSize(width: 200, height: 300)
+        )
+
+        XCTAssertTrue(script.contains("document.elementFromPoint"))
+        XCTAssertTrue(script.contains("PointerEvent"))
+        XCTAssertTrue(script.contains("target.click()"))
+        XCTAssertTrue(script.contains("JSON.stringify"))
+    }
+}
+
+#endif


### PR DESCRIPTION
Fixes #41

Summary:
- projects visible interactive WKWebView DOM controls into get_elements with idSource=dom, source=webview, webviewId, selector, frames, labels, types, and actions
- lets tap_element and tap_text resolve those DOM-backed IDs/text to selector clicks
- routes tap_point inside WKWebView through DOM elementFromPoint using WebView geometry, avoiding UIKit text/editing overlays swallowing WebView taps
- adds React Native iOS package parity for react-native-webview shells and improves WebView DOM click/event dispatch parity on Android
- updates docs and adds DOMSerializer regression tests

Verification:
- Reproduced current issue on iOS Simulator before the fix: get_dom_interactive listed form controls, while get_elements only listed WKWebView wrapper nodes
- SwiftPM: swift test passed, 21 tests
- iOS Simulator: AppRevealExample built and launched on iPhone 17 Pro Max
- iOS live MCP: get_elements now returns web.webdemo.webview.form-email and web.webdemo.webview.form-submit with idSource=dom
- iOS live MCP: tap_element(web.webdemo.webview.form-submit) returned success and changed the page result
- iOS live MCP: tap_text(Submit) returned target=webview_dom and success
- iOS live MCP: tap_point over the Submit button returned target=webview_dom and DOM success
- iOS live MCP: type_text into web.webdemo.webview.form-email updated the DOM input value
- React Native package: pnpm run typecheck passed
- React Native package: pnpm run lint passed
- React Native iOS bridge: swiftc -parse over ios/*.swift passed for iOS Simulator target
- Android: :appreveal:testDebugUnitTest passed
- Android: :appreveal:ktlintCheck passed
- Android Emulator: example/Android/verify-compose-mcp.sh passed on emulator-5554
- git diff --check passed