### PR TITLE
Add Tauri desktop MCP support

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,10 @@ See [React Native guide](ReactNative/README.md) for full setup.
 
 ### Windows
 
-Native .NET and Tauri MCP foundations live under `Windows/`. The Tauri crate
-advertises only its functional foundation tools plus provider-backed tools after
-the host registers real providers. React Native Windows is not autolinked or
+Native .NET and the Rust/Tauri desktop bridge live under `Windows/`. The Tauri
+crate includes a debug-only Tauri v2 plugin, Bonjour/mDNS discovery, live
+WebView DOM inspection/interaction, window focus, menu inspection, and
+provider-backed extension hooks. React Native Windows is not autolinked or
 advertised until there is a real MCP server bridge for that runtime.
 
 ```csharp
@@ -187,7 +188,7 @@ All native UI tools and all web view tools accept an optional `window_id` parame
 
 iOS/macOS/Android: auto-discovers WebViews from the view hierarchy. Flutter: register via `AppReveal.registerWebView(id, controller)`.
 
-On iOS and React Native iOS, visible interactive DOM controls inside `WKWebView` also appear in `get_elements` with `idSource: "dom"` and work with `tap_element`, `tap_text`, `type_text`, and `clear_text`. `tap_point` over a WebView routes through DOM `elementFromPoint(...)` so full-screen WebView shells can still be driven when UIKit text-editing overlays are present.
+On iOS, React Native iOS, and Tauri desktop, visible interactive DOM controls inside WebViews also appear in `get_elements` and work with `tap_element`, `tap_text`, `type_text`, and `clear_text`. `tap_point` over a WebView routes through DOM `elementFromPoint(...)` where the platform can map coordinates into the WebView, so full-screen WebView shells can still be driven when native overlays are present.
 
 | Tool | Description |
 |------|-------------|
@@ -265,7 +266,7 @@ AppReveal gives agents structured data instead of pixels:
 | Flutter | Working | Shared native + web view tool surface |
 | React Native | Working | Shared native + web view tool surface |
 | Windows .NET | Working | Shared MCP contract, UI Automation native/desktop tools |
-| Windows Tauri | Foundation | Shared MCP contract, Tauri provider hooks |
+| Tauri desktop | Working | Shared MCP contract, Bonjour, WebView DOM tools, window/menu inspection |
 
 ## Example apps
 

--- a/Windows/appreveal-tauri/Cargo.toml
+++ b/Windows/appreveal-tauri/Cargo.toml
@@ -4,18 +4,19 @@ version = "0.10.0"
 edition = "2021"
 authors = ["AppReveal Contributors"]
 license = "MIT"
-description = "AppReveal Streamable HTTP JSON-RPC foundation for Rust/Tauri Windows apps"
+description = "AppReveal Streamable HTTP JSON-RPC foundation for Rust/Tauri desktop apps"
 repository = "https://github.com/UnlikeOtherAI/AppReveal"
 homepage = "https://github.com/UnlikeOtherAI/AppReveal"
 documentation = "https://docs.rs/appreveal-tauri"
 readme = "README.md"
-keywords = ["appreveal", "mcp", "tauri", "debug", "windows"]
+keywords = ["appreveal", "mcp", "tauri", "debug", "desktop"]
 categories = ["development-tools::debugging"]
 include = [
     "/Cargo.toml",
     "/README.md",
     "/LICENSE",
     "/PARITY.md",
+    "/examples/**",
     "/src/**",
 ]
 
@@ -25,10 +26,13 @@ path = "src/lib.rs"
 
 [features]
 default = []
-tauri = ["dep:tauri"]
+mdns = ["dep:if-addrs", "dep:mdns-sd"]
+tauri = ["dep:tauri", "mdns"]
 
 [dependencies]
 getrandom = "0.3"
+if-addrs = { version = "0.13", optional = true }
+mdns-sd = { version = "0.13", optional = true }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 tauri = { version = "2", optional = true }

--- a/Windows/appreveal-tauri/PARITY.md
+++ b/Windows/appreveal-tauri/PARITY.md
@@ -1,25 +1,39 @@
 # Tauri parity notes
 
-This crate is the Windows-focused Tauri foundation for AppReveal. It provides the shared HTTP MCP contract, generated session-token authentication, Tauri launch/window metadata, and provider hooks for state, navigation, feature flags, logs, network capture, and future UI tooling.
+This crate is AppReveal's Rust/Tauri desktop bridge. It provides the shared HTTP
+MCP contract, generated session-token authentication, a Tauri v2 plugin
+entrypoint, Bonjour/mDNS discovery, Tauri launch/window metadata, live WebView
+DOM inspection, DOM interaction helpers, menu inspection, and provider hooks for
+state, navigation, feature flags, logs, network capture, and host-specific UI
+tooling.
 
 Implemented:
 
 - `initialize`, `tools/list`, and `tools/call` over HTTP POST.
-- Generated per-session token via `ServerHandle::session_url()` or `AppRevealTauriServer::session_url()`.
+- Generated per-session token via `ServerHandle::session_url()` or
+  `AppRevealTauriServer::session_url()`.
+- Optional Rust mDNS advertiser for `_appreveal._tcp.local.` with the same
+  `transport=streamable-http` and `auth=session-token` TXT records used by the
+  Swift platforms.
+- `appreveal_tauri::init()` and `init_with_config(...)` Tauri plugin entrypoints
+  that start the MCP server only in debug builds by default.
 - Optional `tauri` feature for `tauri::AppHandle` integration.
-- Provider-backed hooks for launch context, device info, windows, logs, state, navigation, feature flags, and network capture.
-- `tools/list` advertises only always-functional built-ins, provider-backed built-ins whose providers are configured, and caller-registered tools.
+- Tauri window metadata and `focus_window`.
+- Live Tauri WebView DOM tools: `get_elements`, `get_dom_interactive`,
+  `tap_element`, `tap_text`, `tap_point`, `type_text`, and `clear_text`.
+- Tauri application menu inspection through `get_menu_bar`.
+- Provider-backed hooks for launch context, device info, windows, logs, state,
+  navigation, feature flags, and network capture.
+- `tools/list` advertises only always-functional built-ins, Tauri runtime tools,
+  provider-backed built-ins whose providers are configured, and caller-registered
+  tools.
 
-Parity gaps:
+Known limits:
 
-- This is not the macOS `tauri/wry` runtime integration requested by GitHub issue #40.
-- No Rust Bonjour/mDNS advertiser is included yet.
-- Native UI, DOM/WebView, screenshots, interaction, menu actions, and recent-error capture need real provider implementations before they should be advertised.
-- The crate does not currently expose a Tauri plugin manifest/API shape.
-
-Next milestones:
-
-- Add a cross-platform Tauri plugin wrapper around the current server handle.
-- Add optional mDNS discovery with the same `_appreveal._tcp` TXT records used by Swift platforms.
-- Add WebView and native UI providers for Tauri/wry windows.
-- Keep the Windows crate behavior provider-backed so WPF, WinUI, WebView2, Tauri, and React Native Windows can share one tool contract.
+- Generic Tauri exposes menu inspection, but not a safe cross-platform API to
+  synthesize activation of arbitrary native menu items. Host apps can still
+  register a custom command/tool for app-specific menu actions.
+- Screenshot capture and native non-WebView UI automation remain provider-backed
+  extension points.
+- DOM tools operate on Tauri WebViews through JavaScript evaluation and require
+  the target page to allow normal in-page DOM event dispatch.

--- a/Windows/appreveal-tauri/README.md
+++ b/Windows/appreveal-tauri/README.md
@@ -1,11 +1,14 @@
 # appreveal-tauri
 
-Debug-only AppReveal MCP foundation for Rust and Tauri Windows apps.
+Debug-only AppReveal MCP support for Rust and Tauri desktop apps, including
+macOS Tauri/wry WebViews.
 
 This crate starts a small loopback HTTP JSON-RPC server that implements
 AppReveal's MCP contract: `initialize`, `tools/list`, and `tools/call`.
-Foundation tools are always available, and provider-backed tools are advertised
-only after the host app registers real providers.
+Foundation tools are always available. With the `tauri` feature, the crate also
+adds a Tauri v2 plugin entrypoint, Bonjour/mDNS discovery, live WebView DOM
+inspection, DOM tap/type helpers, window focus, menu inspection, and Tauri app
+metadata.
 
 ## Install
 
@@ -22,6 +25,21 @@ appreveal-tauri = { version = "0.10.0", features = ["tauri"] }
 
 ## Start in debug builds
 
+For Tauri v2 apps, install the plugin in your builder. It starts only in debug
+builds by default, binds a token-protected MCP server, advertises
+`_appreveal._tcp` via Bonjour/mDNS, and prints the tokenized session URL:
+
+```rust
+tauri::Builder::default()
+    .plugin(appreveal_tauri::init())
+    .run(tauri::generate_context!())?;
+```
+
+Use `init_with_config(appreveal_tauri::TauriPluginConfig { ... })` when an app
+needs a custom port, host, discovery name, or release-build override.
+
+For non-plugin Rust hosts, the lower-level server facade is still available:
+
 ```rust
 #[cfg(debug_assertions)]
 let mut appreveal = appreveal_tauri::AppReveal::new();
@@ -35,8 +53,8 @@ let mut appreveal = appreveal_tauri::AppReveal::new();
 }
 ```
 
-With the optional `tauri` feature, the crate can derive launch context, device
-info, and window metadata from a `tauri::AppHandle`:
+The optional `tauri` feature also exposes the managed starter if your app cannot
+use Tauri's plugin builder:
 
 ```rust
 #[cfg(debug_assertions)]
@@ -50,10 +68,30 @@ The server requires a generated session token by default. Use
 `ServerHandle::session_url()` or `AppRevealTauriServer::session_url()` for the
 tokenized URL during manual testing.
 
+For a direct MCP smoke test without a Tauri app, run:
+
+```sh
+cargo run --example serve
+```
+
+Then curl the printed URL with `initialize`, `tools/list`, or `tools/call`.
+
+## Tauri tools
+
+The Tauri plugin registers these runtime-backed tools:
+
+- `get_elements` and `get_dom_interactive` inspect live interactive DOM nodes in
+  Tauri WebViews using `eval_with_callback`.
+- `tap_element`, `tap_text`, `tap_point`, `type_text`, and `clear_text` dispatch
+  DOM events back into the WebView.
+- `list_windows` comes from the Tauri window provider, and `focus_window` focuses
+  a Tauri WebView window by label.
+- `get_menu_bar` reads the Tauri menu tree when the runtime exposes one.
+
 ## Scope
 
-The crate currently provides the Windows-focused Tauri foundation, shared HTTP
-MCP protocol handling, session-token authentication, provider hooks, and
-optional Tauri app metadata integration. Native UI, DOM/WebView, screenshots,
-interaction, menu actions, and recent-error capture are advertised only when a
-host app registers real implementations.
+The crate now provides a cross-platform Tauri desktop MCP bridge. Generic Tauri
+does not expose a safe API for programmatically activating native menu items, so
+menu support is inspect-only unless a host app registers its own custom command.
+Screenshot capture and native non-WebView UI automation remain provider-backed
+extension points.

--- a/Windows/appreveal-tauri/examples/serve.rs
+++ b/Windows/appreveal-tauri/examples/serve.rs
@@ -1,0 +1,25 @@
+use appreveal_tauri::{AppReveal, Result, ServerConfig};
+use serde_json::json;
+use std::time::Duration;
+
+fn main() -> Result<()> {
+    let mut appreveal = AppReveal::new();
+    appreveal.register_state_provider(|| {
+        json!({
+            "screen": "tauri-example",
+            "frameworkType": "tauri"
+        })
+    });
+
+    let addr = appreveal.start(ServerConfig::localhost(0))?;
+    println!(
+        "AppReveal Tauri example listening at {}",
+        appreveal
+            .session_url()
+            .unwrap_or_else(|| format!("http://{addr}"))
+    );
+
+    loop {
+        std::thread::sleep(Duration::from_secs(60));
+    }
+}

--- a/Windows/appreveal-tauri/src/lib.rs
+++ b/Windows/appreveal-tauri/src/lib.rs
@@ -1,4 +1,4 @@
-//! AppReveal foundation for Rust/Tauri Windows applications.
+//! AppReveal foundation for Rust/Tauri desktop applications.
 //!
 //! This crate exposes AppReveal's Streamable HTTP-ish JSON-RPC contract over a
 //! tiny `std::net::TcpListener` server. It is intentionally small and reusable:
@@ -20,12 +20,12 @@ pub use error::{AppRevealError, Result};
 pub use protocol::{handle_request, JsonRpcRequest, JsonRpcResponse, RpcError};
 pub use providers::{LogQuery, NetworkQuery, ProviderRegistry, WindowInfo};
 pub use registry::{Tool, ToolMetadata, ToolRegistry, ToolResult};
-pub use server::{start_server, ServerConfig, ServerHandle};
+pub use server::{start_server, BonjourConfig, ServerConfig, ServerHandle};
 
 #[cfg(feature = "tauri")]
 pub use tauri_integration::{
-    configure_tauri_providers, providers_from_tauri, start_tauri_server,
-    start_tauri_server_managed, AppRevealTauriServer,
+    configure_tauri_providers, init, init_with_config, providers_from_tauri, start_tauri_server,
+    start_tauri_server_managed, AppRevealTauriServer, TauriPluginConfig,
 };
 
 pub const APPREVEAL_PROTOCOL_VERSION: &str = "2025-06-18";

--- a/Windows/appreveal-tauri/src/server.rs
+++ b/Windows/appreveal-tauri/src/server.rs
@@ -1,20 +1,58 @@
 use crate::error::{AppRevealError, Result};
 use crate::protocol::{handle_request, parse_json_rpc_request, JsonRpcResponse, RpcError};
 use crate::registry::ToolRegistry;
+use std::collections::BTreeMap;
 use std::collections::HashMap;
 use std::io::{BufRead, BufReader, Write};
-use std::net::IpAddr;
-use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::net::{IpAddr, SocketAddr, TcpListener, TcpStream};
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 use std::thread::{self, JoinHandle};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
+
+#[cfg(feature = "mdns")]
+use std::net::{Ipv4Addr, Ipv6Addr};
 
 const DEFAULT_MAX_BODY_SIZE: usize = 1024 * 1024;
 const MAX_HTTP_LINE_SIZE: usize = 16 * 1024;
 const MAX_HTTP_HEADERS: usize = 100;
 const SESSION_TOKEN_HEADER_NAME: &str = "x-appreveal-session";
 const SESSION_TOKEN_QUERY_NAME: &str = "appreveal_session_token";
+const APPREVEAL_SERVICE_TYPE: &str = "_appreveal._tcp.local.";
+
+#[derive(Clone, Debug)]
+pub struct BonjourConfig {
+    pub service_name: String,
+    pub service_type: String,
+    pub host_name: Option<String>,
+    pub txt_records: BTreeMap<String, String>,
+}
+
+impl BonjourConfig {
+    pub fn appreveal(service_name: impl Into<String>) -> Self {
+        let mut txt_records = BTreeMap::new();
+        txt_records.insert("transport".to_string(), "streamable-http".to_string());
+        txt_records.insert("auth".to_string(), "session-token".to_string());
+        txt_records.insert("lan".to_string(), "available".to_string());
+
+        Self {
+            service_name: service_name.into(),
+            service_type: APPREVEAL_SERVICE_TYPE.to_string(),
+            host_name: None,
+            txt_records,
+        }
+    }
+
+    pub fn with_txt_record(mut self, key: impl Into<String>, value: impl Into<String>) -> Self {
+        self.txt_records.insert(key.into(), value.into());
+        self
+    }
+
+    pub fn with_host_name(mut self, host_name: impl Into<String>) -> Self {
+        self.host_name = Some(host_name.into());
+        self
+    }
+}
 
 #[derive(Clone, Debug)]
 pub struct ServerConfig {
@@ -23,6 +61,7 @@ pub struct ServerConfig {
     pub accept_poll_interval: Duration,
     pub max_body_size: usize,
     pub session_token: Option<String>,
+    pub bonjour: Option<BonjourConfig>,
 }
 
 impl ServerConfig {
@@ -42,6 +81,21 @@ impl ServerConfig {
 
     pub fn with_session_token(mut self, token: impl Into<String>) -> Self {
         self.session_token = Some(token.into());
+        self
+    }
+
+    pub fn with_bonjour_service_name(mut self, service_name: impl Into<String>) -> Self {
+        self.bonjour = Some(BonjourConfig::appreveal(service_name));
+        self
+    }
+
+    pub fn with_bonjour(mut self, bonjour: BonjourConfig) -> Self {
+        self.bonjour = Some(bonjour);
+        self
+    }
+
+    pub fn without_bonjour(mut self) -> Self {
+        self.bonjour = None;
         self
     }
 
@@ -71,6 +125,7 @@ impl Default for ServerConfig {
             accept_poll_interval: Duration::from_millis(25),
             max_body_size: DEFAULT_MAX_BODY_SIZE,
             session_token: Some(create_session_token()),
+            bonjour: None,
         }
     }
 }
@@ -79,9 +134,19 @@ pub fn start_server(config: ServerConfig, registry: ToolRegistry) -> Result<Serv
     let listener = TcpListener::bind(config.bind_addr)?;
     listener.set_nonblocking(true)?;
     let local_addr = listener.local_addr()?;
+    let bonjour = start_bonjour(&config, local_addr);
+    let discovery = match (&config.bonjour, &bonjour) {
+        (Some(_), Some(_)) => "bonjour",
+        (Some(_), None) => "bonjour_unavailable",
+        (None, _) => "manual",
+    }
+    .to_string();
     let shutdown = Arc::new(AtomicBool::new(false));
     let thread_shutdown = Arc::clone(&shutdown);
-    let thread_config = config.clone();
+    let mut thread_config = config.clone();
+    if thread_config.bonjour.is_some() && bonjour.is_none() {
+        thread_config.bonjour = None;
+    }
     let session_token = config.session_token.clone();
 
     let thread = thread::spawn(move || {
@@ -91,6 +156,8 @@ pub fn start_server(config: ServerConfig, registry: ToolRegistry) -> Result<Serv
     Ok(ServerHandle {
         local_addr,
         session_token,
+        discovery,
+        _bonjour: bonjour,
         shutdown,
         thread: Some(thread),
     })
@@ -99,6 +166,8 @@ pub fn start_server(config: ServerConfig, registry: ToolRegistry) -> Result<Serv
 pub struct ServerHandle {
     local_addr: SocketAddr,
     session_token: Option<String>,
+    discovery: String,
+    _bonjour: Option<BonjourHandle>,
     shutdown: Arc<AtomicBool>,
     thread: Option<JoinHandle<()>>,
 }
@@ -118,6 +187,10 @@ impl ServerHandle {
 
     pub fn session_token(&self) -> Option<&str> {
         self.session_token.as_deref()
+    }
+
+    pub fn discovery(&self) -> &str {
+        &self.discovery
     }
 
     pub fn session_url(&self) -> String {
@@ -146,6 +219,157 @@ impl ServerHandle {
 impl Drop for ServerHandle {
     fn drop(&mut self) {
         let _ = self.stop();
+    }
+}
+
+#[cfg(feature = "mdns")]
+struct BonjourHandle {
+    daemon: mdns_sd::ServiceDaemon,
+    fullname: String,
+}
+
+#[cfg(not(feature = "mdns"))]
+struct BonjourHandle;
+
+#[cfg(feature = "mdns")]
+impl Drop for BonjourHandle {
+    fn drop(&mut self) {
+        let _ = self.daemon.unregister(&self.fullname);
+        let _ = self.daemon.shutdown();
+    }
+}
+
+#[cfg(feature = "mdns")]
+fn start_bonjour(config: &ServerConfig, local_addr: SocketAddr) -> Option<BonjourHandle> {
+    let Some(bonjour) = config.bonjour.as_ref() else {
+        return None;
+    };
+
+    let daemon = match mdns_sd::ServiceDaemon::new() {
+        Ok(daemon) => daemon,
+        Err(error) => {
+            eprintln!("[AppReveal] Bonjour daemon unavailable: {error}");
+            return None;
+        }
+    };
+
+    let mut txt_records = bonjour.txt_records.clone();
+    txt_records.insert(
+        "auth".to_string(),
+        if config.session_token.is_some() {
+            "session-token".to_string()
+        } else {
+            "disabled".to_string()
+        },
+    );
+
+    let addresses = advertised_addresses(config.bind_addr, local_addr);
+    let host_name = bonjour
+        .host_name
+        .clone()
+        .unwrap_or_else(|| format!("{}.local.", service_host_label(&bonjour.service_name)));
+    let properties = txt_records.into_iter().collect::<Vec<_>>();
+    let service = match mdns_sd::ServiceInfo::new(
+        &bonjour.service_type,
+        &bonjour.service_name,
+        &host_name,
+        &addresses[..],
+        local_addr.port(),
+        &properties[..],
+    ) {
+        Ok(service) => service,
+        Err(error) => {
+            eprintln!("[AppReveal] Bonjour service description failed: {error}");
+            return None;
+        }
+    };
+    let fullname = service.get_fullname().to_string();
+
+    match daemon.register(service) {
+        Ok(()) => {
+            eprintln!(
+                "[AppReveal] Bonjour advertising as {} on port {}",
+                bonjour.service_type,
+                local_addr.port()
+            );
+            Some(BonjourHandle { daemon, fullname })
+        }
+        Err(error) => {
+            eprintln!("[AppReveal] Bonjour advertising failed: {error}");
+            None
+        }
+    }
+}
+
+#[cfg(not(feature = "mdns"))]
+fn start_bonjour(_config: &ServerConfig, _local_addr: SocketAddr) -> Option<BonjourHandle> {
+    None
+}
+
+#[cfg(feature = "mdns")]
+fn advertised_addresses(bind_addr: SocketAddr, local_addr: SocketAddr) -> Vec<IpAddr> {
+    let bound_ip = if bind_addr.ip().is_unspecified() {
+        local_addr.ip()
+    } else {
+        bind_addr.ip()
+    };
+
+    if is_advertisable_ip(bound_ip) {
+        return vec![bound_ip];
+    }
+
+    let mut addresses = if_addrs::get_if_addrs()
+        .map(|interfaces| {
+            interfaces
+                .into_iter()
+                .filter_map(|interface| match interface.addr {
+                    if_addrs::IfAddr::V4(addr) => Some(IpAddr::V4(addr.ip)),
+                    if_addrs::IfAddr::V6(addr) => Some(IpAddr::V6(addr.ip)),
+                })
+                .filter(|ip| is_advertisable_ip(*ip))
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+
+    addresses.sort();
+    addresses.dedup();
+
+    if addresses.is_empty() && !bound_ip.is_unspecified() {
+        addresses.push(bound_ip);
+    }
+
+    addresses
+}
+
+#[cfg(feature = "mdns")]
+fn is_advertisable_ip(ip: IpAddr) -> bool {
+    match ip {
+        IpAddr::V4(ip) => {
+            !ip.is_unspecified() && !ip.is_loopback() && ip != Ipv4Addr::new(255, 255, 255, 255)
+        }
+        IpAddr::V6(ip) => !ip.is_unspecified() && !ip.is_loopback() && ip != Ipv6Addr::LOCALHOST,
+    }
+}
+
+#[cfg(feature = "mdns")]
+fn service_host_label(service_name: &str) -> String {
+    let label = service_name
+        .chars()
+        .map(|character| {
+            if character.is_ascii_alphanumeric() || character == '-' {
+                character
+            } else {
+                '-'
+            }
+        })
+        .collect::<String>()
+        .trim_matches('-')
+        .to_string();
+
+    if label.is_empty() {
+        "AppReveal".to_string()
+    } else {
+        label
     }
 }
 
@@ -215,7 +439,7 @@ fn handle_connection(
             "status": "ok",
             "port": stream.local_addr().map(|addr| addr.port()).unwrap_or(config.bind_addr.port()),
             "auth": if config.session_token.is_some() { "session-token" } else { "disabled" },
-            "discovery": "manual"
+            "discovery": if config.bonjour.is_some() { "bonjour" } else { "manual" }
         });
         return write_json_response(&mut stream, 200, "OK", &body, cors_origin);
     }

--- a/Windows/appreveal-tauri/src/tauri_integration.rs
+++ b/Windows/appreveal-tauri/src/tauri_integration.rs
@@ -1,13 +1,74 @@
 use crate::error::AppRevealError;
-use crate::providers::{current_executable_name, default_device_name, windows_launch_context};
+use crate::providers::{current_executable_name, default_device_name};
 use crate::{
     registry_with_builtins, start_server, ProviderRegistry, Result, ServerConfig, ServerHandle,
-    WindowInfo,
+    Tool, ToolRegistry, WindowInfo,
 };
-use serde_json::{json, Value};
+use serde_json::{json, Map, Value};
 use std::net::SocketAddr;
+use std::sync::mpsc;
 use std::sync::{Mutex, MutexGuard};
-use tauri::{Manager, Runtime};
+use std::time::Duration;
+use tauri::menu::MenuItemKind;
+use tauri::plugin::{Builder, TauriPlugin};
+use tauri::{Manager, Runtime, WebviewWindow};
+
+const APPREVEAL_PLUGIN_NAME: &str = "appreveal";
+const DEFAULT_EVAL_TIMEOUT: Duration = Duration::from_secs(2);
+
+#[derive(Clone, Debug)]
+pub struct TauriPluginConfig {
+    pub server_config: ServerConfig,
+    pub debug_only: bool,
+    pub print_session_url: bool,
+}
+
+impl Default for TauriPluginConfig {
+    fn default() -> Self {
+        Self {
+            server_config: ServerConfig::any_interface(0)
+                .with_bonjour_service_name("AppReveal-Tauri"),
+            debug_only: true,
+            print_session_url: true,
+        }
+    }
+}
+
+pub fn init<R>() -> TauriPlugin<R>
+where
+    R: Runtime,
+{
+    init_with_config(TauriPluginConfig::default())
+}
+
+pub fn init_with_config<R>(config: TauriPluginConfig) -> TauriPlugin<R>
+where
+    R: Runtime,
+{
+    Builder::new(APPREVEAL_PLUGIN_NAME)
+        .setup(move |app, _api| {
+            if config.debug_only && !cfg!(debug_assertions) {
+                return Ok(());
+            }
+
+            let mut server_config = config.server_config.clone();
+            enrich_bonjour_config(app, &mut server_config);
+            start_tauri_server_managed(app.clone(), server_config).map_err(
+                |error| -> Box<dyn std::error::Error> {
+                    Box::new(std::io::Error::other(error.to_string()))
+                },
+            )?;
+
+            if config.print_session_url {
+                if let Ok(Some(url)) = app.state::<AppRevealTauriServer>().session_url() {
+                    println!("[AppReveal] Tauri MCP listening at {url}");
+                }
+            }
+
+            Ok(())
+        })
+        .build()
+}
 
 pub fn providers_from_tauri<R>(app: tauri::AppHandle<R>) -> ProviderRegistry
 where
@@ -35,8 +96,9 @@ pub fn start_tauri_server<R>(app: tauri::AppHandle<R>, config: ServerConfig) -> 
 where
     R: Runtime,
 {
-    let providers = providers_from_tauri(app);
+    let providers = providers_from_tauri(app.clone());
     let registry = registry_with_builtins(providers);
+    register_tauri_tools(&registry, app)?;
     start_server(config, registry)
 }
 
@@ -111,6 +173,582 @@ impl AppRevealTauriServer {
     }
 }
 
+fn register_tauri_tools<R>(registry: &ToolRegistry, app: tauri::AppHandle<R>) -> Result<()>
+where
+    R: Runtime,
+{
+    register_get_elements(registry, app.clone())?;
+    register_get_dom_interactive(registry, app.clone())?;
+    register_tap_element(registry, app.clone())?;
+    register_tap_text(registry, app.clone())?;
+    register_tap_point(registry, app.clone())?;
+    register_type_text(registry, app.clone())?;
+    register_clear_text(registry, app.clone())?;
+    register_focus_window(registry, app.clone())?;
+    register_get_menu_bar(registry, app)?;
+    Ok(())
+}
+
+fn register_get_elements<R>(registry: &ToolRegistry, app: tauri::AppHandle<R>) -> Result<()>
+where
+    R: Runtime,
+{
+    let mut properties = Map::new();
+    properties.insert("window_id".to_string(), json!({ "type": "string" }));
+    registry.register(Tool::new(
+        "get_elements",
+        "List visible interactive DOM elements from Tauri WebViews, including AppReveal IDs, selectors, labels, roles, actions, and screen frames.",
+        object_schema(properties),
+        move |arguments| {
+            let window_id = optional_string_arg(arguments, &["window_id", "windowId"]);
+            collect_dom_elements(&app, window_id.as_deref())
+        },
+    ))
+}
+
+fn register_get_dom_interactive<R>(registry: &ToolRegistry, app: tauri::AppHandle<R>) -> Result<()>
+where
+    R: Runtime,
+{
+    let mut properties = Map::new();
+    properties.insert("window_id".to_string(), json!({ "type": "string" }));
+    registry.register(Tool::new(
+        "get_dom_interactive",
+        "Return the live interactive DOM inventory for each Tauri WebView window.",
+        object_schema(properties),
+        move |arguments| {
+            let window_id = optional_string_arg(arguments, &["window_id", "windowId"]);
+            collect_dom_elements(&app, window_id.as_deref())
+        },
+    ))
+}
+
+fn register_tap_element<R>(registry: &ToolRegistry, app: tauri::AppHandle<R>) -> Result<()>
+where
+    R: Runtime,
+{
+    let mut properties = Map::new();
+    properties.insert("id".to_string(), json!({ "type": "string" }));
+    properties.insert("elementId".to_string(), json!({ "type": "string" }));
+    properties.insert("selector".to_string(), json!({ "type": "string" }));
+    properties.insert("window_id".to_string(), json!({ "type": "string" }));
+    registry.register(Tool::new(
+        "tap_element",
+        "Tap a Tauri WebView DOM element by AppReveal ID, DOM id, data-testid, or CSS selector.",
+        object_schema(properties),
+        move |arguments| {
+            let target = required_string_arg(arguments, &["id", "elementId", "selector"])?;
+            let window_id = optional_string_arg(arguments, &["window_id", "windowId"]);
+            interact_with_dom(&app, "tap_element", &target, None, window_id.as_deref())
+        },
+    ))
+}
+
+fn register_tap_text<R>(registry: &ToolRegistry, app: tauri::AppHandle<R>) -> Result<()>
+where
+    R: Runtime,
+{
+    let mut properties = Map::new();
+    properties.insert("text".to_string(), json!({ "type": "string" }));
+    properties.insert("window_id".to_string(), json!({ "type": "string" }));
+    registry.register(Tool::new(
+        "tap_text",
+        "Tap a Tauri WebView DOM element by visible text or accessible label.",
+        object_schema(properties),
+        move |arguments| {
+            let text = required_string_arg(arguments, &["text"])?;
+            let window_id = optional_string_arg(arguments, &["window_id", "windowId"]);
+            interact_with_dom(&app, "tap_text", &text, None, window_id.as_deref())
+        },
+    ))
+}
+
+fn register_tap_point<R>(registry: &ToolRegistry, app: tauri::AppHandle<R>) -> Result<()>
+where
+    R: Runtime,
+{
+    let mut properties = Map::new();
+    properties.insert("x".to_string(), json!({ "type": "number" }));
+    properties.insert("y".to_string(), json!({ "type": "number" }));
+    properties.insert("window_id".to_string(), json!({ "type": "string" }));
+    registry.register(Tool::new(
+        "tap_point",
+        "Tap a point inside a Tauri WebView. Screen coordinates are converted to WebView-local DOM coordinates when possible.",
+        object_schema(properties),
+        move |arguments| {
+            let x = required_number_arg(arguments, "x")?;
+            let y = required_number_arg(arguments, "y")?;
+            let window_id = optional_string_arg(arguments, &["window_id", "windowId"]);
+            tap_dom_point(&app, x, y, window_id.as_deref())
+        },
+    ))
+}
+
+fn register_type_text<R>(registry: &ToolRegistry, app: tauri::AppHandle<R>) -> Result<()>
+where
+    R: Runtime,
+{
+    let mut properties = Map::new();
+    properties.insert("id".to_string(), json!({ "type": "string" }));
+    properties.insert("elementId".to_string(), json!({ "type": "string" }));
+    properties.insert("selector".to_string(), json!({ "type": "string" }));
+    properties.insert("text".to_string(), json!({ "type": "string" }));
+    properties.insert("window_id".to_string(), json!({ "type": "string" }));
+    registry.register(Tool::new(
+        "type_text",
+        "Type text into a Tauri WebView DOM input, textarea, select, or contenteditable element.",
+        object_schema(properties),
+        move |arguments| {
+            let target = required_string_arg(arguments, &["id", "elementId", "selector"])?;
+            let text = required_string_arg(arguments, &["text"])?;
+            let window_id = optional_string_arg(arguments, &["window_id", "windowId"]);
+            interact_with_dom(
+                &app,
+                "type_text",
+                &target,
+                Some(&text),
+                window_id.as_deref(),
+            )
+        },
+    ))
+}
+
+fn register_clear_text<R>(registry: &ToolRegistry, app: tauri::AppHandle<R>) -> Result<()>
+where
+    R: Runtime,
+{
+    let mut properties = Map::new();
+    properties.insert("id".to_string(), json!({ "type": "string" }));
+    properties.insert("elementId".to_string(), json!({ "type": "string" }));
+    properties.insert("selector".to_string(), json!({ "type": "string" }));
+    properties.insert("window_id".to_string(), json!({ "type": "string" }));
+    registry.register(Tool::new(
+        "clear_text",
+        "Clear text in a Tauri WebView DOM input, textarea, select, or contenteditable element.",
+        object_schema(properties),
+        move |arguments| {
+            let target = required_string_arg(arguments, &["id", "elementId", "selector"])?;
+            let window_id = optional_string_arg(arguments, &["window_id", "windowId"]);
+            interact_with_dom(&app, "clear_text", &target, None, window_id.as_deref())
+        },
+    ))
+}
+
+fn register_focus_window<R>(registry: &ToolRegistry, app: tauri::AppHandle<R>) -> Result<()>
+where
+    R: Runtime,
+{
+    let mut properties = Map::new();
+    properties.insert("window_id".to_string(), json!({ "type": "string" }));
+    properties.insert("windowId".to_string(), json!({ "type": "string" }));
+    registry.register(Tool::new(
+        "focus_window",
+        "Focus a Tauri WebView window by label.",
+        object_schema(properties),
+        move |arguments| {
+            let window_id = required_string_arg(arguments, &["window_id", "windowId"])?;
+            let Some(window) = app.get_webview_window(&window_id) else {
+                return Ok(json!({
+                    "success": false,
+                    "error": "window_not_found",
+                    "windowId": window_id
+                }));
+            };
+
+            match window.set_focus() {
+                Ok(()) => Ok(json!({ "success": true, "windowId": window_id })),
+                Err(error) => Ok(json!({
+                    "success": false,
+                    "error": error.to_string(),
+                    "windowId": window_id
+                })),
+            }
+        },
+    ))
+}
+
+fn register_get_menu_bar<R>(registry: &ToolRegistry, app: tauri::AppHandle<R>) -> Result<()>
+where
+    R: Runtime,
+{
+    registry.register(Tool::new(
+        "get_menu_bar",
+        "Inspect the current Tauri application menu tree when the runtime exposes one.",
+        object_schema(Map::new()),
+        move |_| tauri_menu_bar(&app),
+    ))
+}
+
+fn collect_dom_elements<R>(app: &tauri::AppHandle<R>, window_id: Option<&str>) -> Result<Value>
+where
+    R: Runtime,
+{
+    let mut flattened = Vec::new();
+    let mut webviews = Vec::new();
+
+    for (label, window) in filtered_webview_windows(app, window_id) {
+        let snapshot = eval_json(&window, DOM_SNAPSHOT_JS.to_string())?;
+        let origin = window_css_origin(&window);
+        let mut elements = Vec::new();
+
+        for element in snapshot
+            .get("elements")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default()
+        {
+            let index = element.get("index").and_then(Value::as_u64).unwrap_or(0);
+            let rect = element.get("rect").cloned().unwrap_or_else(|| json!({}));
+            let local_x = rect.get("x").and_then(Value::as_f64).unwrap_or(0.0);
+            let local_y = rect.get("y").and_then(Value::as_f64).unwrap_or(0.0);
+            let width = rect.get("width").and_then(Value::as_f64).unwrap_or(0.0);
+            let height = rect.get("height").and_then(Value::as_f64).unwrap_or(0.0);
+            let screen_x = origin.0 + local_x;
+            let screen_y = origin.1 + local_y;
+            let id = format!("web.{label}.{index}");
+
+            let mapped = json!({
+                "id": id,
+                "windowId": label,
+                "source": "tauri_webview_dom",
+                "idSource": "dom",
+                "domId": element.get("id").cloned().unwrap_or(Value::Null),
+                "selector": element.get("selector").cloned().unwrap_or(Value::Null),
+                "label": element.get("label").cloned().unwrap_or(Value::Null),
+                "text": element.get("text").cloned().unwrap_or(Value::Null),
+                "role": element.get("role").cloned().unwrap_or(Value::Null),
+                "tag": element.get("tag").cloned().unwrap_or(Value::Null),
+                "type": element.get("type").cloned().unwrap_or(Value::Null),
+                "value": element.get("value").cloned().unwrap_or(Value::Null),
+                "actions": element.get("actions").cloned().unwrap_or_else(|| json!([])),
+                "enabled": element.get("enabled").cloned().unwrap_or_else(|| json!(true)),
+                "visible": element.get("visible").cloned().unwrap_or_else(|| json!(true)),
+                "frame": format!("{screen_x:.0},{screen_y:.0},{width:.0},{height:.0}"),
+                "rect": {
+                    "x": screen_x,
+                    "y": screen_y,
+                    "width": width,
+                    "height": height
+                },
+                "localRect": rect
+            });
+            flattened.push(mapped.clone());
+            elements.push(mapped);
+        }
+
+        webviews.push(json!({
+            "windowId": label,
+            "url": snapshot.get("url").cloned().unwrap_or(Value::Null),
+            "title": snapshot.get("title").cloned().unwrap_or(Value::Null),
+            "viewport": snapshot.get("viewport").cloned().unwrap_or(Value::Null),
+            "elements": elements
+        }));
+    }
+
+    let count = flattened.len();
+    Ok(json!({
+        "elements": flattened,
+        "webviews": webviews,
+        "count": count
+    }))
+}
+
+fn interact_with_dom<R>(
+    app: &tauri::AppHandle<R>,
+    action: &str,
+    target: &str,
+    text: Option<&str>,
+    window_id: Option<&str>,
+) -> Result<Value>
+where
+    R: Runtime,
+{
+    let (resolved_window_id, resolved_target) = resolve_appreveal_dom_target(target, window_id);
+    for (label, window) in filtered_webview_windows(app, resolved_window_id.as_deref()) {
+        let script = dom_action_script(action, Some(&resolved_target), text, None, None);
+        let mut result = eval_json(&window, script)?;
+        result["windowId"] = json!(label);
+        result["target"] = json!("webview_dom");
+        if result
+            .get("success")
+            .and_then(Value::as_bool)
+            .unwrap_or(false)
+        {
+            return Ok(result);
+        }
+    }
+
+    Ok(json!({
+        "success": false,
+        "target": "webview_dom",
+        "action": action,
+        "error": "target_not_found"
+    }))
+}
+
+fn tap_dom_point<R>(
+    app: &tauri::AppHandle<R>,
+    x: f64,
+    y: f64,
+    window_id: Option<&str>,
+) -> Result<Value>
+where
+    R: Runtime,
+{
+    let windows = filtered_webview_windows(app, window_id);
+    if windows.is_empty() {
+        return Ok(json!({
+            "success": false,
+            "target": "webview_dom",
+            "action": "tap_point",
+            "error": "window_not_found"
+        }));
+    }
+
+    let selected = windows
+        .iter()
+        .find_map(|(label, window)| {
+            local_point_if_inside(window, x, y).map(|point| (label, window, point))
+        })
+        .or_else(|| {
+            windows
+                .first()
+                .map(|(label, window)| (label, window, (x, y)))
+        });
+
+    let Some((label, window, point)) = selected else {
+        return Ok(json!({
+            "success": false,
+            "target": "webview_dom",
+            "action": "tap_point",
+            "error": "window_not_found"
+        }));
+    };
+
+    let script = dom_action_script("tap_point", None, None, Some(point.0), Some(point.1));
+    let mut result = eval_json(window, script)?;
+    result["windowId"] = json!(label);
+    result["target"] = json!("webview_dom");
+    Ok(result)
+}
+
+fn tauri_menu_bar<R>(app: &tauri::AppHandle<R>) -> Result<Value>
+where
+    R: Runtime,
+{
+    let Some(menu) = app.menu() else {
+        return Ok(json!({
+            "menus": [],
+            "count": 0
+        }));
+    };
+
+    let items = menu
+        .items()
+        .map_err(|error| AppRevealError::Tool(error.to_string()))?
+        .iter()
+        .map(menu_item_to_json)
+        .collect::<Result<Vec<_>>>()?;
+    let count = items.len();
+
+    Ok(json!({
+        "menus": items,
+        "count": count
+    }))
+}
+
+fn menu_item_to_json<R>(item: &MenuItemKind<R>) -> Result<Value>
+where
+    R: Runtime,
+{
+    match item {
+        MenuItemKind::MenuItem(item) => Ok(json!({
+            "id": item.id().as_ref(),
+            "title": item.text().unwrap_or_default(),
+            "kind": "item",
+            "enabled": item.is_enabled().unwrap_or(false)
+        })),
+        MenuItemKind::Submenu(item) => {
+            let children = item
+                .items()
+                .map_err(|error| AppRevealError::Tool(error.to_string()))?
+                .iter()
+                .map(menu_item_to_json)
+                .collect::<Result<Vec<_>>>()?;
+            Ok(json!({
+                "id": item.id().as_ref(),
+                "title": item.text().unwrap_or_default(),
+                "kind": "submenu",
+                "enabled": item.is_enabled().unwrap_or(false),
+                "items": children
+            }))
+        }
+        MenuItemKind::Predefined(item) => Ok(json!({
+            "id": item.id().as_ref(),
+            "title": item.text().unwrap_or_default(),
+            "kind": "predefined"
+        })),
+        MenuItemKind::Check(item) => Ok(json!({
+            "id": item.id().as_ref(),
+            "title": item.text().unwrap_or_default(),
+            "kind": "check",
+            "enabled": item.is_enabled().unwrap_or(false),
+            "checked": item.is_checked().unwrap_or(false)
+        })),
+        MenuItemKind::Icon(item) => Ok(json!({
+            "id": item.id().as_ref(),
+            "title": item.text().unwrap_or_default(),
+            "kind": "icon",
+            "enabled": item.is_enabled().unwrap_or(false)
+        })),
+    }
+}
+
+fn eval_json<R>(window: &WebviewWindow<R>, script: String) -> Result<Value>
+where
+    R: Runtime,
+{
+    let (sender, receiver) = mpsc::channel();
+    window
+        .eval_with_callback(script, move |payload| {
+            let _ = sender.send(payload);
+        })
+        .map_err(|error| AppRevealError::Tool(error.to_string()))?;
+
+    let payload = receiver.recv_timeout(DEFAULT_EVAL_TIMEOUT).map_err(|_| {
+        AppRevealError::Tool("Timed out waiting for Tauri WebView JavaScript result".to_string())
+    })?;
+    let value: Value = serde_json::from_str(&payload)?;
+    if let Some(inner) = value.as_str() {
+        serde_json::from_str(inner).map_err(AppRevealError::from)
+    } else {
+        Ok(value)
+    }
+}
+
+fn filtered_webview_windows<R>(
+    app: &tauri::AppHandle<R>,
+    window_id: Option<&str>,
+) -> Vec<(String, WebviewWindow<R>)>
+where
+    R: Runtime,
+{
+    app.webview_windows()
+        .into_iter()
+        .filter(|(label, _)| {
+            window_id
+                .map(|window_id| window_id == label)
+                .unwrap_or(true)
+        })
+        .collect()
+}
+
+fn resolve_appreveal_dom_target(
+    target: &str,
+    explicit_window_id: Option<&str>,
+) -> (Option<String>, String) {
+    if let Some((window_id, index)) = target
+        .strip_prefix("web.")
+        .and_then(|rest| rest.split_once('.'))
+    {
+        return (
+            explicit_window_id
+                .map(ToOwned::to_owned)
+                .or_else(|| Some(window_id.to_string())),
+            format!("index:{index}"),
+        );
+    }
+
+    (
+        explicit_window_id.map(ToOwned::to_owned),
+        target.to_string(),
+    )
+}
+
+fn window_css_origin<R>(window: &WebviewWindow<R>) -> (f64, f64)
+where
+    R: Runtime,
+{
+    let scale = window.scale_factor().unwrap_or(1.0).max(1.0);
+    window
+        .inner_position()
+        .map(|position| (position.x as f64 / scale, position.y as f64 / scale))
+        .unwrap_or((0.0, 0.0))
+}
+
+fn local_point_if_inside<R>(window: &WebviewWindow<R>, x: f64, y: f64) -> Option<(f64, f64)>
+where
+    R: Runtime,
+{
+    let scale = window.scale_factor().unwrap_or(1.0).max(1.0);
+    let origin = window_css_origin(window);
+    let size = window.inner_size().ok()?;
+    let width = size.width as f64 / scale;
+    let height = size.height as f64 / scale;
+
+    if x >= origin.0 && y >= origin.1 && x <= origin.0 + width && y <= origin.1 + height {
+        Some((x - origin.0, y - origin.1))
+    } else {
+        None
+    }
+}
+
+fn object_schema(properties: Map<String, Value>) -> Value {
+    json!({
+        "type": "object",
+        "properties": properties
+    })
+}
+
+fn optional_string_arg(arguments: Option<&Value>, names: &[&str]) -> Option<String> {
+    arguments.and_then(Value::as_object).and_then(|arguments| {
+        names.iter().find_map(|name| {
+            arguments
+                .get(*name)
+                .and_then(Value::as_str)
+                .filter(|value| !value.trim().is_empty())
+                .map(ToOwned::to_owned)
+        })
+    })
+}
+
+fn required_string_arg(arguments: Option<&Value>, names: &[&str]) -> Result<String> {
+    optional_string_arg(arguments, names).ok_or_else(|| {
+        AppRevealError::InvalidParams(format!("Missing required string argument: {}", names[0]))
+    })
+}
+
+fn required_number_arg(arguments: Option<&Value>, name: &str) -> Result<f64> {
+    arguments
+        .and_then(Value::as_object)
+        .and_then(|arguments| arguments.get(name))
+        .and_then(Value::as_f64)
+        .ok_or_else(|| AppRevealError::InvalidParams(format!("Missing required number: {name}")))
+}
+
+fn enrich_bonjour_config<R>(app: &tauri::AppHandle<R>, config: &mut ServerConfig)
+where
+    R: Runtime,
+{
+    let Some(bonjour) = config.bonjour.as_mut() else {
+        return;
+    };
+
+    let bundle_id = app.config().identifier.clone();
+    let version = app.package_info().version.to_string();
+    if bonjour.service_name == "AppReveal-Tauri" {
+        bonjour.service_name = format!("AppReveal-{bundle_id}");
+    }
+    bonjour
+        .txt_records
+        .entry("bundleId".to_string())
+        .or_insert(bundle_id);
+    bonjour
+        .txt_records
+        .entry("version".to_string())
+        .or_insert(version);
+}
+
 fn tauri_launch_context<R>(app: &tauri::AppHandle<R>) -> Value
 where
     R: Runtime,
@@ -118,15 +756,26 @@ where
     let package = app.package_info();
     let bundle_id = app.config().identifier.clone();
     let app_name = package.name.clone();
+    let process_name = current_executable_name();
 
-    windows_launch_context(
-        bundle_id,
-        app_name.clone(),
-        app_name,
-        package.version.to_string(),
-        "0".to_string(),
-        "tauri",
-    )
+    json!({
+        "bundleId": bundle_id,
+        "applicationId": bundle_id,
+        "appName": app_name,
+        "displayName": app_name,
+        "version": package.version.to_string(),
+        "versionName": package.version.to_string(),
+        "build": "0",
+        "versionCode": 0,
+        "platform": platform_name(),
+        "frameworkType": "tauri",
+        "systemName": platform_name(),
+        "systemVersion": std::env::consts::OS,
+        "deviceModel": desktop_model_name(),
+        "deviceName": default_device_name(),
+        "processName": process_name,
+        "processId": std::process::id()
+    })
 }
 
 fn tauri_device_info<R>(app: &tauri::AppHandle<R>) -> Value
@@ -139,7 +788,7 @@ where
     let device_name = default_device_name();
 
     json!({
-        "platform": "Windows",
+        "platform": platform_name(),
         "frameworkType": "tauri",
         "bundleId": launch_context["bundleId"].clone(),
         "applicationId": launch_context["applicationId"].clone(),
@@ -150,8 +799,8 @@ where
         "build": launch_context["build"].clone(),
         "versionCode": launch_context["versionCode"].clone(),
         "deviceName": device_name,
-        "deviceModel": "Windows PC",
-        "systemName": "Windows",
+        "deviceModel": desktop_model_name(),
+        "systemName": platform_name(),
         "systemVersion": std::env::consts::OS,
         "processName": process_name,
         "processId": process_id,
@@ -165,14 +814,14 @@ where
                 .unwrap_or_else(current_executable_name)
         },
         "os": {
-            "platform": "Windows",
+            "platform": platform_name(),
             "family": std::env::consts::FAMILY,
             "name": std::env::consts::OS,
             "arch": std::env::consts::ARCH
         },
         "device": {
             "name": device_name,
-            "model": "Windows PC"
+            "model": desktop_model_name()
         },
         "windows": {
             "count": app.webview_windows().len()
@@ -202,3 +851,330 @@ where
         })
         .collect()
 }
+
+fn platform_name() -> &'static str {
+    match std::env::consts::OS {
+        "macos" => "macOS",
+        "windows" => "Windows",
+        "linux" => "Linux",
+        value => value,
+    }
+}
+
+fn desktop_model_name() -> &'static str {
+    match std::env::consts::OS {
+        "macos" => "Mac",
+        "windows" => "Windows PC",
+        "linux" => "Linux PC",
+        _ => "Desktop",
+    }
+}
+
+fn dom_action_script(
+    action: &str,
+    target: Option<&str>,
+    text: Option<&str>,
+    x: Option<f64>,
+    y: Option<f64>,
+) -> String {
+    let action = serde_json::to_string(action).expect("action serializes");
+    let target = serde_json::to_string(&target).expect("target serializes");
+    let text = serde_json::to_string(&text).expect("text serializes");
+    let x = x
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "null".to_string());
+    let y = y
+        .map(|value| value.to_string())
+        .unwrap_or_else(|| "null".to_string());
+
+    format!(
+        r#"
+(() => {{
+  const action = {action};
+  const target = {target};
+  const inputText = {text};
+  const pointX = {x};
+  const pointY = {y};
+  const interactiveSelector = [
+    'a[href]',
+    'button',
+    'input',
+    'textarea',
+    'select',
+    'summary',
+    '[role="button"]',
+    '[role="link"]',
+    '[role="checkbox"]',
+    '[role="radio"]',
+    '[role="switch"]',
+    '[tabindex]:not([tabindex="-1"])',
+    '[contenteditable="true"]',
+    '[contenteditable=""]',
+    '[data-testid]',
+    '[data-test]',
+    '[aria-label]'
+  ].join(',');
+  const cssEscape = value => {{
+    if (window.CSS && CSS.escape) return CSS.escape(String(value));
+    return String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  }};
+  const visible = element => {{
+    if (!element || element.nodeType !== Node.ELEMENT_NODE) return false;
+    const rect = element.getBoundingClientRect();
+    const style = getComputedStyle(element);
+    return rect.width > 0 && rect.height > 0 && style.display !== 'none' && style.visibility !== 'hidden';
+  }};
+  const label = element => (
+    element.getAttribute('aria-label') ||
+    element.getAttribute('title') ||
+    element.getAttribute('placeholder') ||
+    element.innerText ||
+    element.value ||
+    element.textContent ||
+    ''
+  ).trim().replace(/\s+/g, ' ');
+  const selectorFor = element => {{
+    if (element.id) return '#' + cssEscape(element.id);
+    for (const attr of ['data-testid', 'data-test', 'name', 'aria-label']) {{
+      const value = element.getAttribute(attr);
+      if (value) return `[${{attr}}="${{cssEscape(value)}}"]`;
+    }}
+    const parts = [];
+    let current = element;
+    while (current && current.nodeType === Node.ELEMENT_NODE && current !== document.body) {{
+      let part = current.tagName.toLowerCase();
+      const parent = current.parentElement;
+      if (parent) {{
+        const siblings = Array.from(parent.children).filter(child => child.tagName === current.tagName);
+        if (siblings.length > 1) part += `:nth-of-type(${{siblings.indexOf(current) + 1}})`;
+      }}
+      parts.unshift(part);
+      current = parent;
+    }}
+    return parts.length ? parts.join(' > ') : element.tagName.toLowerCase();
+  }};
+  const roleFor = element => {{
+    const explicit = element.getAttribute('role');
+    if (explicit) return explicit;
+    const tag = element.tagName.toLowerCase();
+    if (tag === 'button') return 'button';
+    if (tag === 'a') return 'link';
+    if (tag === 'select') return 'combobox';
+    if (tag === 'textarea') return 'textbox';
+    if (tag === 'input') {{
+      const type = (element.getAttribute('type') || 'text').toLowerCase();
+      if (type === 'checkbox') return 'checkbox';
+      if (type === 'radio') return 'radio';
+      if (type === 'submit' || type === 'button') return 'button';
+      return 'textbox';
+    }}
+    return tag;
+  }};
+  const actionsFor = element => {{
+    const actions = ['tap'];
+    const tag = element.tagName.toLowerCase();
+    const type = (element.getAttribute('type') || '').toLowerCase();
+    if (tag === 'input' || tag === 'textarea' || element.isContentEditable) actions.push('type_text', 'clear_text');
+    if (tag === 'select') actions.push('select');
+    if (type === 'checkbox' || type === 'radio' || element.getAttribute('role') === 'switch') actions.push('toggle');
+    return actions;
+  }};
+  const descriptor = (element, index = null) => {{
+    const rect = element.getBoundingClientRect();
+    return {{
+      index,
+      id: element.id || element.getAttribute('data-testid') || element.getAttribute('data-test') || element.getAttribute('name') || (index === null ? null : String(index)),
+      selector: selectorFor(element),
+      tag: element.tagName.toLowerCase(),
+      role: roleFor(element),
+      type: element.getAttribute('type') || null,
+      label: label(element),
+      text: (element.innerText || element.textContent || '').trim().replace(/\s+/g, ' '),
+      value: 'value' in element ? element.value : null,
+      enabled: !element.disabled && element.getAttribute('aria-disabled') !== 'true',
+      visible: visible(element),
+      rect: {{ x: rect.left, y: rect.top, width: rect.width, height: rect.height }},
+      actions: actionsFor(element)
+    }};
+  }};
+  const elements = () => Array.from(document.querySelectorAll(interactiveSelector)).filter(visible);
+  const findTarget = () => {{
+    if (action === 'tap_point') return document.elementFromPoint(pointX, pointY);
+    if (!target) return null;
+    const all = elements();
+    if (target.startsWith('index:')) {{
+      const index = Number.parseInt(target.slice('index:'.length), 10);
+      return Number.isFinite(index) ? all[index] : null;
+    }}
+    try {{
+      const selected = document.querySelector(target);
+      if (selected) return selected;
+    }} catch (_) {{}}
+    const normalized = target.trim().toLowerCase();
+    return all.find((element, index) => {{
+      const descriptorForElement = descriptor(element, index);
+      const candidates = [
+        String(index),
+        descriptorForElement.id,
+        descriptorForElement.selector,
+        element.getAttribute('data-testid'),
+        element.getAttribute('data-test'),
+        element.getAttribute('name'),
+        descriptorForElement.label,
+        descriptorForElement.text
+      ].filter(Boolean).map(value => String(value).trim().toLowerCase());
+      return candidates.includes(normalized);
+    }});
+  }};
+  const dispatchInput = element => {{
+    element.dispatchEvent(new InputEvent('input', {{ bubbles: true, inputType: 'insertText', data: inputText || '' }}));
+    element.dispatchEvent(new Event('change', {{ bubbles: true }}));
+  }};
+  const dispatchClick = element => {{
+    element.scrollIntoView({{ block: 'center', inline: 'center' }});
+    const rect = element.getBoundingClientRect();
+    const clientX = action === 'tap_point' ? pointX : rect.left + rect.width / 2;
+    const clientY = action === 'tap_point' ? pointY : rect.top + rect.height / 2;
+    for (const type of ['pointerdown', 'mousedown', 'pointerup', 'mouseup', 'click']) {{
+      const event = type.startsWith('pointer')
+        ? new PointerEvent(type, {{ bubbles: true, cancelable: true, clientX, clientY, pointerId: 1, pointerType: 'mouse', isPrimary: true }})
+        : new MouseEvent(type, {{ bubbles: true, cancelable: true, clientX, clientY, button: 0 }});
+      element.dispatchEvent(event);
+    }}
+  }};
+
+  const element = findTarget();
+  if (!element) return {{ success: false, action, error: 'target_not_found' }};
+
+  if (action === 'type_text' || action === 'clear_text') {{
+    element.focus();
+    if (element.isContentEditable) {{
+      element.textContent = action === 'clear_text' ? '' : `${{element.textContent || ''}}${{inputText || ''}}`;
+    }} else if ('value' in element) {{
+      element.value = action === 'clear_text' ? '' : `${{element.value || ''}}${{inputText || ''}}`;
+    }} else {{
+      return {{ success: false, action, error: 'target_not_editable', element: descriptor(element) }};
+    }}
+    dispatchInput(element);
+  }} else {{
+    dispatchClick(element);
+  }}
+
+  return {{ success: true, action, element: descriptor(element) }};
+}})()
+"#
+    )
+}
+
+const DOM_SNAPSHOT_JS: &str = r#"
+(() => {
+  const interactiveSelector = [
+    'a[href]',
+    'button',
+    'input',
+    'textarea',
+    'select',
+    'summary',
+    '[role="button"]',
+    '[role="link"]',
+    '[role="checkbox"]',
+    '[role="radio"]',
+    '[role="switch"]',
+    '[tabindex]:not([tabindex="-1"])',
+    '[contenteditable="true"]',
+    '[contenteditable=""]',
+    '[data-testid]',
+    '[data-test]',
+    '[aria-label]'
+  ].join(',');
+  const cssEscape = value => {
+    if (window.CSS && CSS.escape) return CSS.escape(String(value));
+    return String(value).replace(/\\/g, '\\\\').replace(/"/g, '\\"');
+  };
+  const visible = element => {
+    if (!element || element.nodeType !== Node.ELEMENT_NODE) return false;
+    const rect = element.getBoundingClientRect();
+    const style = getComputedStyle(element);
+    return rect.width > 0 && rect.height > 0 && style.display !== 'none' && style.visibility !== 'hidden';
+  };
+  const label = element => (
+    element.getAttribute('aria-label') ||
+    element.getAttribute('title') ||
+    element.getAttribute('placeholder') ||
+    element.innerText ||
+    element.value ||
+    element.textContent ||
+    ''
+  ).trim().replace(/\s+/g, ' ');
+  const selectorFor = element => {
+    if (element.id) return '#' + cssEscape(element.id);
+    for (const attr of ['data-testid', 'data-test', 'name', 'aria-label']) {
+      const value = element.getAttribute(attr);
+      if (value) return `[${attr}="${cssEscape(value)}"]`;
+    }
+    const parts = [];
+    let current = element;
+    while (current && current.nodeType === Node.ELEMENT_NODE && current !== document.body) {
+      let part = current.tagName.toLowerCase();
+      const parent = current.parentElement;
+      if (parent) {
+        const siblings = Array.from(parent.children).filter(child => child.tagName === current.tagName);
+        if (siblings.length > 1) part += `:nth-of-type(${siblings.indexOf(current) + 1})`;
+      }
+      parts.unshift(part);
+      current = parent;
+    }
+    return parts.length ? parts.join(' > ') : element.tagName.toLowerCase();
+  };
+  const roleFor = element => {
+    const explicit = element.getAttribute('role');
+    if (explicit) return explicit;
+    const tag = element.tagName.toLowerCase();
+    if (tag === 'button') return 'button';
+    if (tag === 'a') return 'link';
+    if (tag === 'select') return 'combobox';
+    if (tag === 'textarea') return 'textbox';
+    if (tag === 'input') {
+      const type = (element.getAttribute('type') || 'text').toLowerCase();
+      if (type === 'checkbox') return 'checkbox';
+      if (type === 'radio') return 'radio';
+      if (type === 'submit' || type === 'button') return 'button';
+      return 'textbox';
+    }
+    return tag;
+  };
+  const actionsFor = element => {
+    const actions = ['tap'];
+    const tag = element.tagName.toLowerCase();
+    const type = (element.getAttribute('type') || '').toLowerCase();
+    if (tag === 'input' || tag === 'textarea' || element.isContentEditable) actions.push('type_text', 'clear_text');
+    if (tag === 'select') actions.push('select');
+    if (type === 'checkbox' || type === 'radio' || element.getAttribute('role') === 'switch') actions.push('toggle');
+    return actions;
+  };
+  const elements = Array.from(document.querySelectorAll(interactiveSelector)).filter(visible);
+  return {
+    url: location.href,
+    title: document.title,
+    viewport: { width: innerWidth, height: innerHeight },
+    elements: elements.map((element, index) => {
+      const rect = element.getBoundingClientRect();
+      return {
+        index,
+        id: element.id || element.getAttribute('data-testid') || element.getAttribute('data-test') || element.getAttribute('name') || String(index),
+        selector: selectorFor(element),
+        tag: element.tagName.toLowerCase(),
+        role: roleFor(element),
+        type: element.getAttribute('type') || null,
+        label: label(element),
+        text: (element.innerText || element.textContent || '').trim().replace(/\s+/g, ' '),
+        value: 'value' in element ? element.value : null,
+        enabled: !element.disabled && element.getAttribute('aria-disabled') !== 'true',
+        visible: true,
+        rect: { x: rect.left, y: rect.top, width: rect.width, height: rect.height },
+        actions: actionsFor(element)
+      };
+    })
+  };
+})()
+"#;

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -116,7 +116,7 @@ Optional element-level cropping by accessibility identifier.
 
 ### WebViewBridge / MacOSWebViewBridge
 
-Discovers `WKWebView` instances inside the selected window and powers the DOM tools. On iOS and React Native iOS, `get_elements` also projects visible interactive DOM controls as DOM-backed AppReveal elements (`idSource: "dom"`) so `tap_element`, `tap_text`, `type_text`, and `clear_text` can drive WebView forms without a separate selector lookup. On iOS, `tap_point` routes coordinates inside a `WKWebView` to `document.elementFromPoint(...).click()` using WebView geometry, which avoids UIKit text-editing overlays swallowing WebView taps.
+Discovers WebView instances inside the selected window and powers the DOM tools. On iOS, React Native iOS, and Tauri desktop, `get_elements` also projects visible interactive DOM controls as DOM-backed AppReveal elements so `tap_element`, `tap_text`, `type_text`, and `clear_text` can drive WebView forms without a separate selector lookup. On iOS and Tauri, `tap_point` routes coordinates inside a WebView to `document.elementFromPoint(...)` using WebView geometry, which avoids native overlays swallowing WebView taps.
 
 - Auto-discovers web views from the native view hierarchy
 - Evaluates JavaScript for DOM inspection and interaction

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -1,6 +1,6 @@
 # MCP Tools Reference
 
-AppReveal exposes a shared MCP tool surface for native UI, state, network, diagnostics, WebView DOM, and batch operations. Desktop targets add `list_windows` plus menu/window tools, and native UI/WebView tools accept an optional `window_id` parameter for multi-window targeting where the platform supports it. Windows integrations use capability-aware registration: .NET advertises its functional UI Automation tools by default, while Tauri lists only implemented built-ins and host-registered extensions.
+AppReveal exposes a shared MCP tool surface for native UI, state, network, diagnostics, WebView DOM, and batch operations. Desktop targets add `list_windows` plus menu/window tools, and native UI/WebView tools accept an optional `window_id` parameter for multi-window targeting where the platform supports it. Windows integrations use capability-aware registration: .NET advertises its functional UI Automation tools by default, while Tauri lists implemented built-ins, runtime-backed WebView/window/menu tools, and host-registered extensions.
 
 All current server implementations require a generated per-session token for MCP POST requests and expose `GET /health` as an unauthenticated liveness/diagnostics endpoint.
 
@@ -500,7 +500,7 @@ React Native response mirrors iOS or Android depending on the host platform.
 
 All WebView tools accept an optional `webview_id` parameter. If omitted, the first discovered WebView is used. Use `get_webviews` to list available WebViews and their IDs.
 
-On iOS and React Native iOS, `get_elements` includes visible interactive DOM controls inside discovered `WKWebView`s with `idSource: "dom"`, `source: "webview"`, `webviewId`, and `selector`. Those IDs work with `tap_element`, `tap_text`, `type_text`, and `clear_text`. For richer DOM-level work, use `get_webviews`, then `get_dom_interactive`, `get_dom_forms`, `find_dom_text`, `web_click`, and `web_type`.
+On iOS, React Native iOS, and Tauri desktop, `get_elements` includes visible interactive DOM controls inside discovered WebViews with DOM-backed IDs, selectors, labels, roles, actions, and frames. Those IDs work with `tap_element`, `tap_text`, `type_text`, and `clear_text`; Tauri also routes `tap_point` inside its WebView using `document.elementFromPoint(...)`. For richer DOM-level work, use `get_webviews`, then `get_dom_interactive`, `get_dom_forms`, `find_dom_text`, `web_click`, and `web_type` where the platform advertises those tools.
 
 ### `get_webviews`
 List all web views in the current screen.
@@ -743,7 +743,7 @@ batch's JSON results.
 
 ## Desktop Tools
 
-These tools are available on desktop targets such as macOS and Windows when the target implementation has a menu/window provider.
+These tools are available on desktop targets such as macOS, Windows, and Tauri when the target implementation has a menu/window provider. Generic Tauri can inspect menu trees but cannot synthesize arbitrary native menu activation without an app-specific command.
 
 ### `get_menu_bar`
 Read the app's main menu bar hierarchy recursively.

--- a/docs/windows.md
+++ b/docs/windows.md
@@ -41,36 +41,29 @@ header. Discovery advertisement stays disabled unless
 
 ## Tauri
 
-`Windows/appreveal-tauri` is a Rust crate for Tauri apps. It exposes the same
-HTTP MCP contract and an optional `tauri` feature that derives launch context,
-device info, and window metadata from a `tauri::AppHandle`.
+`Windows/appreveal-tauri` is a Rust crate for Tauri desktop apps, including
+macOS Tauri/wry apps. It exposes the same HTTP MCP contract and an optional
+`tauri` feature that adds a Tauri v2 plugin, Bonjour/mDNS discovery, launch
+context, device info, window metadata, WebView DOM tools, window focus, and menu
+inspection.
 
 ```rust
-#[cfg(debug_assertions)]
-appreveal_tauri::start_tauri_server_managed(
-    app.handle().clone(),
-    appreveal_tauri::ServerConfig::localhost(0),
-)?;
-
-#[cfg(debug_assertions)]
-if let Some(url) = app
-    .state::<appreveal_tauri::AppRevealTauriServer>()
-    .session_url()?
-{
-    println!("AppReveal listening at {url}");
-}
+tauri::Builder::default()
+    .plugin(appreveal_tauri::init())
+    .run(tauri::generate_context!())?;
 ```
 
 The Tauri crate always advertises the functional foundation tools
 `launch_context`, `device_info`, and `batch`. The optional `tauri` feature adds
-real launch context, device info, and window metadata from a `tauri::AppHandle`,
-so `list_windows` is advertised when that window provider is configured.
+real launch context, device info, and window metadata from a `tauri::AppHandle`;
+`list_windows`, `focus_window`, and `get_menu_bar`; and live WebView DOM tools:
+`get_elements`, `get_dom_interactive`, `tap_element`, `tap_text`, `tap_point`,
+`type_text`, and `clear_text`.
 
 Provider-backed tools for logs, state, navigation, feature flags, and network
 capture are listed only after the app registers the corresponding real provider.
-Native UI, DOM/WebView, screenshots, interaction, menu actions, and recent-error
-capture are not advertised until the app registers real tools/providers for
-those features.
+Screenshot capture, native non-WebView UI automation, recent-error capture, and
+app-specific menu activation remain provider-backed extension points.
 The HTTP server requires a generated session token by
 default; use `ServerHandle::session_url()` or
 `AppRevealTauriServer::session_url()` for manual testing, or pass an explicit
@@ -82,12 +75,11 @@ The native .NET package advertises functional Windows UI, state, diagnostics,
 network, batch, and desktop window/menu tools. WebView DOM tools are advertised
 only when a host WebView provider is registered.
 
-The Tauri crate advertises its implemented foundation tools, available
-provider-backed built-ins, and caller-registered extensions. It does not list
-state, diagnostics, native UI, menu, interaction, screenshot, DOM, or
-recent-error tools until the app supplies real implementations.
-
-The Tauri crate is a Windows/Tauri foundation. macOS Tauri/wry DOM and native UI providers remain a separate parity milestone tracked in `Windows/appreveal-tauri/PARITY.md`.
+The Tauri crate advertises its implemented foundation tools, runtime-backed
+Tauri tools, available provider-backed built-ins, and caller-registered
+extensions. Generic Tauri supports menu inspection, but not synthetic activation
+of arbitrary native menu items, so hosts should register an app-specific command
+when they need write-side menu control.
 
 For production release builds, keep AppReveal behind debug guards just like the
 other platforms.


### PR DESCRIPTION
Fixes #40.

## Summary
- Adds cross-platform Rust/Tauri desktop support with a Tauri v2 plugin entrypoint.
- Adds optional Bonjour/mDNS discovery for `_appreveal._tcp.local.` with AppReveal TXT records.
- Adds live Tauri WebView DOM inspection and interaction tools: `get_elements`, `get_dom_interactive`, `tap_element`, `tap_text`, `tap_point`, `type_text`, and `clear_text`.
- Adds Tauri window focus and menu inspection tools, a direct serve example, and refreshed docs/parity notes.

## Verification
- `cargo test --manifest-path Windows/appreveal-tauri/Cargo.toml -- --test-threads=1`
- `cargo test --manifest-path Windows/appreveal-tauri/Cargo.toml --features tauri -- --test-threads=1`
- `cargo package --manifest-path Windows/appreveal-tauri/Cargo.toml --allow-dirty --no-verify`
- `cargo run --manifest-path Windows/appreveal-tauri/Cargo.toml --example serve` + curl `/health`, `initialize`, and `get_state`
- iOS Simulator build/run: AppRevealExample on iPhone 17 Pro Max
- iOS Simulator curl `/health` + `initialize` against AppReveal session URL
- `swift test` in `iOS/`
- Android Emulator: `example/Android/verify-compose-mcp.sh` on `emulator-5554`
- Android library: `./gradlew :appreveal:testDebugUnitTest :appreveal:ktlintCheck`
- `git diff --check`