### PR TITLE
Fix SwiftUI TextField AppReveal typing

### DIFF
--- a/example/iOS/AppRevealExample/Screens/TapCalibrationViewController.swift
+++ b/example/iOS/AppRevealExample/Screens/TapCalibrationViewController.swift
@@ -165,7 +165,7 @@ private struct SwiftUITapTestView: View {
                 .padding(.horizontal, 24)
                 .accessibilityIdentifier("calibration.swiftui_field")
                 #if DEBUG
-                .appReveal("calibration.swiftui_field", label: "Type here (SwiftUI)")
+                .appReveal("calibration.swiftui_field", label: "Type here (SwiftUI)", type: .textField)
                 #endif
         }
     }

--- a/iOS/Sources/AppReveal/Elements/ElementInventory.swift
+++ b/iOS/Sources/AppReveal/Elements/ElementInventory.swift
@@ -645,17 +645,17 @@ final class ElementInventory {
             elements.append(
                 ElementInfo(
                     id: finalId,
-                    type: .button,
+                    type: entry.type,
                     label: entry.label,
                     value: nil,
                     enabled: true,
                     visible: !frame.isEmpty,
-                    tappable: true,
+                    tappable: entry.isTappable,
                     frame: Self.makeFrame(frame),
                     safeAreaInsets: safeAreaInsets,
                     safeAreaLayoutGuideFrame: Self.makeFrame(frame),
                     containerId: nil,
-                    actions: ["tap"],
+                    actions: entry.actions,
                     idSource: "appReveal"
                 )
             )
@@ -673,8 +673,9 @@ final class ElementInventory {
                 "userInteraction": true,
                 "depth": 0,
                 "accessibilityId": entry.id,
+                "elementType": entry.type.rawValue,
                 "idSource": "appReveal",
-                "actions": ["tap"]
+                "actions": entry.actions
             ]
             if let label = entry.label, !label.isEmpty {
                 node["accessibilityLabel"] = label

--- a/iOS/Sources/AppReveal/Elements/MacOSElementInventory.swift
+++ b/iOS/Sources/AppReveal/Elements/MacOSElementInventory.swift
@@ -452,17 +452,17 @@ final class ElementInventory {
             elements.append(
                 ElementInfo(
                     id: finalId,
-                    type: .button,
+                    type: entry.type,
                     label: entry.label,
                     value: nil,
                     enabled: true,
                     visible: !frame.isEmpty,
-                    tappable: true,
+                    tappable: entry.isTappable,
                     frame: Self.makeFrame(frame),
                     safeAreaInsets: safeAreaInsets,
                     safeAreaLayoutGuideFrame: Self.makeFrame(frame),
                     containerId: nil,
-                    actions: ["tap"],
+                    actions: entry.actions,
                     idSource: "appReveal"
                 )
             )
@@ -479,8 +479,9 @@ final class ElementInventory {
                 "alphaValue": 1,
                 "depth": 0,
                 "accessibilityId": entry.id,
+                "elementType": entry.type.rawValue,
                 "idSource": "appReveal",
-                "actions": ["tap"]
+                "actions": entry.actions
             ]
             if let label = entry.label, !label.isEmpty {
                 node["accessibilityLabel"] = label

--- a/iOS/Sources/AppReveal/Elements/SwiftUIElementRegistry.swift
+++ b/iOS/Sources/AppReveal/Elements/SwiftUIElementRegistry.swift
@@ -27,44 +27,85 @@ final class SwiftUIElementRegistry {
 
     static let shared = SwiftUIElementRegistry()
 
-    private struct Entry {
+    struct RegisteredElement {
+        let id: String
         let frame: CGRect
         let label: String?
+        let type: ElementType
         let windowId: String?
         let activate: (() -> Void)?
+
+        var actions: [String] {
+            switch type {
+            case .textField:
+                return ["tap", "type", "clear"]
+            case .label, .image, .other:
+                return []
+            default:
+                return ["tap"]
+            }
+        }
+
+        var isTappable: Bool {
+            actions.contains("tap")
+        }
     }
 
-    private var entries: [String: Entry] = [:]
+    private var entries: [String: RegisteredElement] = [:]
+    private var pendingUnregisterTokens: [String: UUID] = [:]
 
     private init() {}
 
-    func register(id: String, frame: CGRect, label: String?, activate: (() -> Void)? = nil) {
-        entries[id] = Entry(
+    func register(
+        id: String,
+        frame: CGRect,
+        label: String?,
+        type: ElementType = .button,
+        activate: (() -> Void)? = nil
+    ) {
+        pendingUnregisterTokens[id] = nil
+        entries[id] = RegisteredElement(
+            id: id,
             frame: frame,
             label: label,
+            type: type,
             windowId: Self.windowId(containing: frame),
             activate: activate
         )
     }
 
     func unregister(id: String) {
-        entries.removeValue(forKey: id)
-    }
-
-    func currentElements(windowIds: Set<String>) -> [(id: String, frame: CGRect, label: String?)] {
-        entries.compactMap { id, entry in
-            guard Self.entry(entry, matchesAnyOf: windowIds) else { return nil }
-            return (id: id, frame: entry.frame, label: entry.label)
+        let token = UUID()
+        pendingUnregisterTokens[id] = token
+        Task { @MainActor in
+            try? await Task.sleep(nanoseconds: 300_000_000)
+            guard pendingUnregisterTokens[id] == token else { return }
+            entries.removeValue(forKey: id)
+            pendingUnregisterTokens[id] = nil
         }
     }
 
-    func findElement(byId id: String, windowIds: Set<String>) -> (id: String, frame: CGRect, label: String?)? {
-        guard let entry = entries[id] else { return nil }
-        guard Self.entry(entry, matchesAnyOf: windowIds) else { return nil }
-        return (id: id, frame: entry.frame, label: entry.label)
+    func currentElements(windowIds: Set<String>) -> [RegisteredElement] {
+        entries.compactMap { id, entry in
+            guard Self.entry(entry, matchesAnyOf: windowIds) else { return nil }
+            return RegisteredElement(
+                id: id,
+                frame: entry.frame,
+                label: entry.label,
+                type: entry.type,
+                windowId: entry.windowId,
+                activate: entry.activate
+            )
+        }
     }
 
-    func matchingElements(text: String, matchMode: String, windowIds: Set<String>) -> [(id: String, frame: CGRect, label: String?)] {
+    func findElement(byId id: String, windowIds: Set<String>) -> RegisteredElement? {
+        guard let entry = entries[id] else { return nil }
+        guard Self.entry(entry, matchesAnyOf: windowIds) else { return nil }
+        return entry
+    }
+
+    func matchingElements(text: String, matchMode: String, windowIds: Set<String>) -> [RegisteredElement] {
         entries.compactMap { id, entry in
             guard Self.entry(entry, matchesAnyOf: windowIds) else { return nil }
             let candidates = [entry.label, id].compactMap { $0 }
@@ -76,7 +117,7 @@ final class SwiftUIElementRegistry {
                     return candidate.caseInsensitiveCompare(text) == .orderedSame
                 }
             }
-            return matches ? (id: id, frame: entry.frame, label: entry.label) : nil
+            return matches ? entry : nil
         }
     }
 
@@ -89,7 +130,7 @@ final class SwiftUIElementRegistry {
         return true
     }
 
-    private static func entry(_ entry: Entry, matchesAnyOf windowIds: Set<String>) -> Bool {
+    private static func entry(_ entry: RegisteredElement, matchesAnyOf windowIds: Set<String>) -> Bool {
         guard !windowIds.isEmpty else { return true }
         guard let windowId = entry.windowId ?? windowId(containing: entry.frame) else { return true }
         return windowIds.contains(windowId)
@@ -132,13 +173,15 @@ private struct AppRevealFramePreference: PreferenceKey {
 struct AppRevealModifier: ViewModifier {
     let id: String
     let label: String?
+    let type: ElementType
     let activate: (() -> Void)?
 
     func body(content: Content) -> some View {
         content
-            .background(
+            .overlay(
                 GeometryReader { geo in
                     Color.clear
+                        .allowsHitTesting(false)
                         .preference(
                             key: AppRevealFramePreference.self,
                             value: geo.frame(in: .global)
@@ -154,6 +197,7 @@ struct AppRevealModifier: ViewModifier {
                         id: registeredId,
                         frame: frame,
                         label: registeredLabel,
+                        type: type,
                         activate: activate
                     )
                 }
@@ -191,10 +235,16 @@ public extension View {
     /// - Parameters:
     ///   - id: Stable dot-namespaced identifier (e.g. `"chat.send_button"`).
     ///   - label: Optional human-readable label for the element.
+    ///   - type: Element type AppReveal should advertise for this view.
     ///   - activate: Optional direct debug activation closure. Use this for SwiftUI
     ///     controls whose gestures are intercepted by ScrollView/Lazy containers.
-    func appReveal(_ id: String, label: String? = nil, activate: (() -> Void)? = nil) -> some View {
-        modifier(AppRevealModifier(id: id, label: label, activate: activate))
+    func appReveal(
+        _ id: String,
+        label: String? = nil,
+        type: ElementType = .button,
+        activate: (() -> Void)? = nil
+    ) -> some View {
+        modifier(AppRevealModifier(id: id, label: label, type: type, activate: activate))
     }
 }
 

--- a/iOS/Sources/AppReveal/Interaction/InteractionEngine.swift
+++ b/iOS/Sources/AppReveal/Interaction/InteractionEngine.swift
@@ -709,12 +709,43 @@ final class InteractionEngine {
                 return editableAncestor(for: hitView)
             }
             return nil
-        case .appReveal(_, let point):
+        case .appReveal(let id, let point):
+            if let entry = SwiftUIElementRegistry.shared.findElement(
+                byId: id,
+                windowIds: Set(candidateWindows(windowId: windowId).map(\.id))
+            ), entry.type == .textField {
+                if let editable = focusSwiftUIRegisteredTextField(at: point, windowId: windowId) {
+                    return editable
+                }
+            }
             if let hitView = hitView(at: point, windowId: windowId, preferredWindow: nil) {
                 return editableAncestor(for: hitView)
             }
             return nil
         }
+    }
+
+    private func focusSwiftUIRegisteredTextField(at point: CGPoint, windowId: String?) -> UIView? {
+        if let hitView = hitView(at: point, windowId: windowId, preferredWindow: nil),
+           let editable = editableAncestor(for: hitView) {
+            editable.becomeFirstResponder()
+            return editable
+        }
+
+        _ = tap(point: point, windowId: windowId)
+        RunLoop.main.run(until: Date().addingTimeInterval(0.1))
+
+        if let responder = currentEditableResponder(windowId: windowId) {
+            return responder
+        }
+
+        if let hitView = hitView(at: point, windowId: windowId, preferredWindow: nil),
+           let editable = editableAncestor(for: hitView) {
+            editable.becomeFirstResponder()
+            return editable
+        }
+
+        return nil
     }
 
     private func currentEditableResponder(windowId: String?) -> UIView? {

--- a/iOS/Tests/AppRevealTests/SwiftUIElementRegistryTests.swift
+++ b/iOS/Tests/AppRevealTests/SwiftUIElementRegistryTests.swift
@@ -1,0 +1,56 @@
+import XCTest
+@testable import AppReveal
+
+#if DEBUG && (os(iOS) || os(macOS))
+
+@MainActor
+final class SwiftUIElementRegistryTests: XCTestCase {
+    func testRegisteredTextFieldAdvertisesEditableActions() {
+        let id = "test.swiftui.field.\(UUID().uuidString)"
+
+        SwiftUIElementRegistry.shared.register(
+            id: id,
+            frame: CGRect(x: 10, y: 20, width: 120, height: 36),
+            label: "Editable field",
+            type: .textField
+        )
+
+        let element = SwiftUIElementRegistry.shared.findElement(byId: id, windowIds: [])
+
+        XCTAssertEqual(element?.type, .textField)
+        XCTAssertEqual(element?.label, "Editable field")
+        XCTAssertEqual(element?.actions, ["tap", "type", "clear"])
+        XCTAssertEqual(element?.isTappable, true)
+
+        SwiftUIElementRegistry.shared.unregister(id: id)
+    }
+
+    func testTransientUnregisterIsCancelledByReregister() async throws {
+        let id = "test.swiftui.transient.\(UUID().uuidString)"
+
+        SwiftUIElementRegistry.shared.register(
+            id: id,
+            frame: CGRect(x: 10, y: 20, width: 120, height: 36),
+            label: "First",
+            type: .button
+        )
+
+        SwiftUIElementRegistry.shared.unregister(id: id)
+        SwiftUIElementRegistry.shared.register(
+            id: id,
+            frame: CGRect(x: 12, y: 22, width: 130, height: 40),
+            label: "Second",
+            type: .textField
+        )
+
+        try await Task.sleep(nanoseconds: 350_000_000)
+
+        let element = SwiftUIElementRegistry.shared.findElement(byId: id, windowIds: [])
+        XCTAssertEqual(element?.label, "Second")
+        XCTAssertEqual(element?.type, .textField)
+
+        SwiftUIElementRegistry.shared.unregister(id: id)
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary
- preserve SwiftUI AppReveal element type metadata instead of advertising every opt-in SwiftUI view as a button
- expose TextField opt-ins with `tap,type,clear` actions and use the registered frame to focus/type into them
- debounce transient SwiftUI unregisters so focus/layout rebuilds do not briefly drop registered elements
- mark the iOS calibration TextField as a TextField and add registry regression coverage

## Root cause
SwiftUI opt-in elements were stored as frame/label only, so `get_elements` could not expose the explicit TextField id as an editable target. During focus/layout changes SwiftUI could also transiently unregister the opt-in element, causing direct `type_text(element_id:)` to miss it even though the visible field existed.

Fixes #39

## Verification
- `swift test` in `iOS/` — 23 tests passed
- iOS Simulator `AppRevealExample` on iPhone 17 Pro Max — `calibration.swiftui_field` appears as `textField` with `tap,type,clear`; `type_text` by element id succeeds; point-tap/no-id typing still succeeds; SwiftUI button point tap fires
- Android Emulator `emulator-5554` — `example/Android/verify-compose-mcp.sh` passed
- Android library — `./gradlew :appreveal:testDebugUnitTest :appreveal:ktlintCheck` passed
- `git diff --check` passed
