### PR TITLE
Fix SwiftUI lazy grid point taps

### DIFF
--- a/example/iOS/AppRevealExample/Screens/TapCalibrationViewController.swift
+++ b/example/iOS/AppRevealExample/Screens/TapCalibrationViewController.swift
@@ -72,7 +72,8 @@ final class TapCalibrationViewController: UIViewController {
         let swiftUIVC = UIHostingController(rootView: SwiftUITapTestView(
             onTap: { [weak self] in self?.swiftUIButtonTapped() },
             onIdentifierOnlyTap: { [weak self] in self?.swiftUIIdentifierOnlyButtonTapped() },
-            onImageTap: { [weak self] in self?.swiftUIImageButtonTapped() }
+            onImageTap: { [weak self] in self?.swiftUIImageButtonTapped() },
+            onLazyGridTap: { [weak self] in self?.swiftUILazyGridButtonTapped() }
         ))
         addChild(swiftUIVC)
         swiftUIVC.view.translatesAutoresizingMaskIntoConstraints = false
@@ -83,7 +84,7 @@ final class TapCalibrationViewController: UIViewController {
             swiftUIVC.view.topAnchor.constraint(equalTo: imageButtonResultLabel.bottomAnchor, constant: 16),
             swiftUIVC.view.leadingAnchor.constraint(equalTo: view.leadingAnchor),
             swiftUIVC.view.trailingAnchor.constraint(equalTo: view.trailingAnchor),
-            swiftUIVC.view.heightAnchor.constraint(equalToConstant: 180)
+            swiftUIVC.view.heightAnchor.constraint(equalToConstant: 320)
         ])
     }
 
@@ -115,14 +116,26 @@ final class TapCalibrationViewController: UIViewController {
         resultLabel.text = "Identifier-only SwiftUI button tapped!"
         resultLabel.textColor = .systemPurple
     }
+
+    private func swiftUILazyGridButtonTapped() {
+        resultLabel.text = "Lazy grid SwiftUI button tapped!"
+        resultLabel.textColor = .systemMint
+    }
 }
 
 private struct SwiftUITapTestView: View {
     let onTap: () -> Void
     let onIdentifierOnlyTap: () -> Void
     let onImageTap: () -> Void
+    let onLazyGridTap: () -> Void
 
     @State private var textFieldValue = ""
+
+    private let columns = [
+        GridItem(.flexible()),
+        GridItem(.flexible()),
+        GridItem(.flexible())
+    ]
 
     var body: some View {
         VStack(spacing: 8) {
@@ -167,6 +180,43 @@ private struct SwiftUITapTestView: View {
                 #if DEBUG
                 .appReveal("calibration.swiftui_field", label: "Type here (SwiftUI)", type: .textField)
                 #endif
+
+            Text("Lazy Grid Button Test")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+
+            ScrollView(.vertical, showsIndicators: true) {
+                LazyVGrid(columns: columns, spacing: 8) {
+                    lazyGridButton(action: onLazyGridTap, color: .green)
+                        #if DEBUG
+                        .appReveal("calibration.lazy_grid_card", activate: onLazyGridTap)
+                        #endif
+
+                    ForEach(1..<12) { index in
+                        RoundedRectangle(cornerRadius: 12)
+                            .fill(index.isMultiple(of: 2) ? Color.blue.opacity(0.25) : Color.orange.opacity(0.25))
+                            .frame(height: 56)
+                    }
+                }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 8)
+            }
+            .frame(height: 96)
         }
+    }
+
+    private func lazyGridButton(action: @escaping () -> Void, color: Color) -> some View {
+        Button(action: action) {
+            RoundedRectangle(cornerRadius: 12)
+                .fill(color.opacity(0.85))
+                .frame(height: 56)
+                .overlay {
+                    Circle()
+                        .fill(Color.white.opacity(0.35))
+                        .frame(width: 22, height: 22)
+                        .accessibilityHidden(true)
+                }
+        }
+        .buttonStyle(.plain)
     }
 }

--- a/iOS/Sources/AppReveal/Elements/SwiftUIElementRegistry.swift
+++ b/iOS/Sources/AppReveal/Elements/SwiftUIElementRegistry.swift
@@ -105,6 +105,18 @@ final class SwiftUIElementRegistry {
         return entry
     }
 
+    func findTappableElement(at point: CGPoint, windowIds: Set<String>) -> RegisteredElement? {
+        entries.values
+            .filter { entry in
+                entry.isTappable &&
+                    entry.frame.contains(point) &&
+                    Self.entry(entry, matchesAnyOf: windowIds)
+            }
+            .min { lhs, rhs in
+                lhs.frame.area < rhs.frame.area
+            }
+    }
+
     func matchingElements(text: String, matchMode: String, windowIds: Set<String>) -> [RegisteredElement] {
         entries.compactMap { id, entry in
             guard Self.entry(entry, matchesAnyOf: windowIds) else { return nil }
@@ -157,6 +169,7 @@ final class SwiftUIElementRegistry {
 
 extension CGRect {
     var center: CGPoint { CGPoint(x: midX, y: midY) }
+    var area: CGFloat { width * height }
 }
 
 // MARK: - SwiftUI PreferenceKey

--- a/iOS/Sources/AppReveal/Interaction/InteractionEngine.swift
+++ b/iOS/Sources/AppReveal/Interaction/InteractionEngine.swift
@@ -117,6 +117,17 @@ final class InteractionEngine {
                 }
             }
 
+            // SwiftUI controls inside ScrollView/Lazy containers can swallow a synthetic
+            // point tap before their Button action runs. If the app opted this view into
+            // AppReveal with a direct debug activation closure, prefer that deterministic
+            // path for point taps whose coordinates land inside the registered frame.
+            if let registeredElement = SwiftUIElementRegistry.shared.findTappableElement(
+                at: point,
+                windowIds: [ref.id]
+            ), SwiftUIElementRegistry.shared.activate(id: registeredElement.id) {
+                return true
+            }
+
             // SwiftUI hosting views need a dedicated tap path. On iOS 26+ SwiftUI moved all
             // touch handling into UIKit's window-level event dispatch, so direct touchesBegan
             // calls are ignored. We try accessibilityActivate() first (SwiftUI Button

--- a/iOS/Tests/AppRevealTests/SwiftUIElementRegistryTests.swift
+++ b/iOS/Tests/AppRevealTests/SwiftUIElementRegistryTests.swift
@@ -51,6 +51,34 @@ final class SwiftUIElementRegistryTests: XCTestCase {
 
         SwiftUIElementRegistry.shared.unregister(id: id)
     }
+
+    func testFindTappableElementAtPointPrefersSmallestContainingFrame() {
+        let outerId = "test.swiftui.outer.\(UUID().uuidString)"
+        let innerId = "test.swiftui.inner.\(UUID().uuidString)"
+
+        SwiftUIElementRegistry.shared.register(
+            id: outerId,
+            frame: CGRect(x: 0, y: 0, width: 200, height: 200),
+            label: "Outer",
+            type: .button
+        )
+        SwiftUIElementRegistry.shared.register(
+            id: innerId,
+            frame: CGRect(x: 50, y: 50, width: 40, height: 40),
+            label: "Inner",
+            type: .button
+        )
+
+        let element = SwiftUIElementRegistry.shared.findTappableElement(
+            at: CGPoint(x: 60, y: 60),
+            windowIds: []
+        )
+
+        XCTAssertEqual(element?.id, innerId)
+
+        SwiftUIElementRegistry.shared.unregister(id: outerId)
+        SwiftUIElementRegistry.shared.unregister(id: innerId)
+    }
 }
 
 #endif


### PR DESCRIPTION
## Summary
- route `tap_point` through registered SwiftUI AppReveal elements when the point lands inside their frame and a direct activation closure is available
- add a live iOS calibration repro for an unlabeled SwiftUI button inside `ScrollView > LazyVGrid`
- add registry coverage for point containment resolution, preferring the smallest containing registered frame

## Root cause
SwiftUI buttons inside scroll/lazy containers can accept the synthetic point tap without running the Button action because the scroll gesture stack intercepts the gesture first. AppReveal already supported direct debug activation for `.appReveal(..., activate:)` targets by id/text, but `tap_point` never checked the registered SwiftUI frame before falling back to synthetic touch delivery.

Fixes #38

## Verification
- Reproduced before the engine fix on iOS Simulator: `tap_point` at `calibration.lazy_grid_card` center returned success but the result label stayed `Target not yet tapped`
- Verified after the fix on iOS Simulator: same point changed the result label to `Lazy grid SwiftUI button tapped!`
- `swift test` in `iOS/` — 24 tests passed
- `swiftlint lint --strict` in `iOS/` — 0 violations
- Android Emulator `emulator-5554` — `example/Android/verify-compose-mcp.sh` passed
- Android library — `./gradlew :appreveal:testDebugUnitTest :appreveal:ktlintCheck` passed
- `git diff --check` passed
