### PR TITLE
Retry iOS Bonjour after foregrounding

### DIFF
--- a/docs/ios.md
+++ b/docs/ios.md
@@ -154,6 +154,7 @@ For manual testing you can also paste the printed `AppReveal.sessionURL`, which 
 - `bonjour: "advertising"` means mDNS published successfully.
 - `bonjour: "suppressed"` means AppReveal kept the HTTP listener running but did not advertise because no usable LAN interface/path was visible. Check `bonjourDiagnostics.suppressionReason`.
 - `bonjour: "retrying"` or `"failed"` includes `lastError` and `lastErrorHint`; `-65555` is Bonjour `NoAuth`, usually Local Network permission or missing `NSBonjourServices`.
+- If iOS asks for Local Network permission after `AppReveal.start()`, grant it and return to the app. AppReveal retries Bonjour when the app becomes active again, so you do not need to restart the debug build.
 - `lan.interfaces` lists the process-visible IPv4/IPv6 interfaces and marks which ones are LAN candidates.
 
 ## Integration protocols

--- a/iOS/Sources/AppReveal/MCPServer/MCPServer.swift
+++ b/iOS/Sources/AppReveal/MCPServer/MCPServer.swift
@@ -2,6 +2,9 @@
 
 import Foundation
 import Network
+#if os(iOS)
+import UIKit
+#endif
 
 #if DEBUG
 
@@ -25,6 +28,9 @@ final class MCPServer {
     private var pendingBonjourPublication: BonjourPublication?
     private var networkMonitor: NWPathMonitor?
     private let networkMonitorQueue = DispatchQueue(label: "ai.unlikeother.appreveal.network-monitor")
+    #if os(iOS)
+    private var appLifecycleObservers: [NSObjectProtocol] = []
+    #endif
     private var networkPathStatus = "unknown"
     private var networkPathInterfaces: [String] = []
     private var lanInterfaces: [AppRevealLANInterface] = []
@@ -70,6 +76,7 @@ final class MCPServer {
         let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "0.0.0"
         refreshLANDiagnostics()
         startNetworkPathMonitor()
+        startAppLifecycleObservers()
         logBonjourConfigurationHints()
 
         let nwListener = listener
@@ -113,6 +120,7 @@ final class MCPServer {
         bonjourRetryTask = nil
         networkMonitor?.cancel()
         networkMonitor = nil
+        stopAppLifecycleObservers()
         bonjourService?.stop()
         bonjourService = nil
         bonjourDelegate = nil
@@ -587,6 +595,7 @@ final class MCPServer {
         bonjourRetryTask?.cancel()
         bonjourRetryTask = nil
         bonjourRetryDelaySeconds = nil
+        bonjourRetryAttempt = 0
         print("[AppReveal] Retrying Bonjour now (\(reason)).")
         publishBonjour(port: publication.port, bundleId: publication.bundleId, version: publication.version)
     }
@@ -622,6 +631,37 @@ final class MCPServer {
         }
         networkMonitor = monitor
         monitor.start(queue: networkMonitorQueue)
+    }
+
+    private func startAppLifecycleObservers() {
+        #if os(iOS)
+        guard appLifecycleObservers.isEmpty else { return }
+
+        let didBecomeActive = NotificationCenter.default.addObserver(
+            forName: UIApplication.didBecomeActiveNotification,
+            object: nil,
+            queue: nil
+        ) { [weak self] _ in
+            Task { @MainActor [weak self] in
+                guard let self else { return }
+                self.refreshLANDiagnostics()
+                if self.pendingBonjourPublication != nil, self.bonjourService == nil {
+                    self.retryBonjourNow(reason: "app_did_become_active")
+                }
+            }
+        }
+
+        appLifecycleObservers.append(didBecomeActive)
+        #endif
+    }
+
+    private func stopAppLifecycleObservers() {
+        #if os(iOS)
+        for observer in appLifecycleObservers {
+            NotificationCenter.default.removeObserver(observer)
+        }
+        appLifecycleObservers.removeAll()
+        #endif
     }
 
     private func bonjourDiagnosticsPayload() -> [String: Any] {

--- a/iOS/Tests/AppRevealTests/LANDiagnosticsTests.swift
+++ b/iOS/Tests/AppRevealTests/LANDiagnosticsTests.swift
@@ -1,0 +1,46 @@
+import XCTest
+@testable import AppReveal
+
+#if DEBUG && (os(iOS) || os(macOS))
+
+final class LANDiagnosticsTests: XCTestCase {
+    func testWarningsCallOutMissingLocalNetworkDeclarations() {
+        let warnings = AppRevealLANDiagnostics.warnings(
+            info: [:],
+            interfaces: [],
+            pathStatus: "unsatisfied"
+        )
+
+        XCTAssertTrue(warnings.contains { $0.contains("NSLocalNetworkUsageDescription") })
+        XCTAssertTrue(warnings.contains { $0.contains("NSBonjourServices") })
+        XCTAssertTrue(warnings.contains { $0.contains("No active non-loopback LAN address") })
+        XCTAssertTrue(warnings.contains { $0.contains("unsatisfied path") })
+    }
+
+    func testWarningsAcceptAppRevealBonjourServiceWithTrailingDot() {
+        let warnings = AppRevealLANDiagnostics.warnings(
+            info: [
+                "NSLocalNetworkUsageDescription": "Debug local network access",
+                "NSBonjourServices": ["_appreveal._tcp."]
+            ],
+            interfaces: [
+                AppRevealLANInterface(
+                    name: "en0",
+                    family: "ipv4",
+                    address: "192.168.1.155",
+                    isLoopback: false,
+                    isPointToPoint: false,
+                    isLinkLocal: false
+                )
+            ],
+            pathStatus: "satisfied"
+        )
+
+        XCTAssertFalse(warnings.contains { $0.contains("NSLocalNetworkUsageDescription") })
+        XCTAssertFalse(warnings.contains { $0.contains("NSBonjourServices") })
+        XCTAssertFalse(warnings.contains { $0.contains("No active non-loopback LAN address") })
+        XCTAssertFalse(warnings.contains { $0.contains("unsatisfied path") })
+    }
+}
+
+#endif


### PR DESCRIPTION
## Summary
- retry Bonjour publication when an iOS app becomes active again after startup
- reset the Bonjour retry counter for foreground-triggered retries so granting Local Network permission after the first retry window can recover without restarting the debug build
- document the iOS permission flow in the LAN diagnostics section
- add diagnostics tests for required Local Network / Bonjour declarations

## Root cause
On physical iOS devices, Local Network permission can be granted after `AppReveal.start()` has already attempted Bonjour publication. If the initial publish attempts exhaust while permission/network state is unavailable, AppReveal can remain without an `_appreveal._tcp` advertisement until the app is restarted. Retrying when the app becomes active covers the common “grant permission, return to app” flow.

Fixes #37

## Verification
- iOS Simulator `AppRevealExample` on iPhone 17 Pro Max: build/run succeeded; logs show `Bonjour advertising as _appreveal._tcp`
- Simulator `/health`: `bonjour=advertising`, `pathStatus=satisfied`, `hasUsableLANAddress=true`, no LAN warnings
- Simulator authenticated `initialize`: succeeded and returned AppReveal server info
- `swift test` in `iOS/` — 26 tests passed
- `swiftlint lint --strict` in `iOS/` — 0 violations
- Android Emulator `emulator-5554` — `example/Android/verify-compose-mcp.sh` passed
- Android library — `./gradlew :appreveal:testDebugUnitTest :appreveal:ktlintCheck` passed
- `git diff --check` passed

## Physical-device note
A connected iPhone 16 Pro Max was detected, but a live device run could not be completed from this environment: command-line signing for the example app is missing an active Xcode account/provisioning profile, and launching the already-installed RPGPT app was denied because the device is locked. The code change targets the physical-device Local Network permission recovery path directly, but this PR still relies on simulator/runtime verification plus unit/CI coverage for that environment limitation.
