### PR TITLE
Release AppReveal 0.10.1

### DIFF
--- a/Android/appreveal/src/main/kotlin/com/appreveal/AppRevealVersion.kt
+++ b/Android/appreveal/src/main/kotlin/com/appreveal/AppRevealVersion.kt
@@ -2,4 +2,4 @@ package com.appreveal
 
 // Single source of truth for the AppReveal framework version.
 // Update this constant on every release to match the git tag.
-internal const val APPREVEAL_VERSION = "0.10.0"
+internal const val APPREVEAL_VERSION = "0.10.1"

--- a/CLI/package.json
+++ b/CLI/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@unlikeotherai/appreveal",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "CLI for discovering and querying AppReveal MCP servers on the local network",
   "type": "module",
   "bin": {

--- a/CLI/src/index.ts
+++ b/CLI/src/index.ts
@@ -30,7 +30,7 @@ import {
 
 const DEFAULT_DISCOVERY_TIMEOUT_MS = 5000;
 const DEFAULT_ELEMENT_LIMIT = 8;
-const CLI_VERSION = '0.10.0';
+const CLI_VERSION = '0.10.1';
 
 const program = new Command();
 

--- a/Flutter/appreveal/lib/appreveal.dart
+++ b/Flutter/appreveal/lib/appreveal.dart
@@ -180,7 +180,7 @@ class AppReveal {
 
     // Advertise via mDNS (use real bundle ID from PackageInfo)
     String bundleId = 'com.appreveal.app';
-    String version = '0.10.0';
+    String version = '0.10.1';
     try {
       final info = await PackageInfo.fromPlatform();
       bundleId = info.packageName;

--- a/Flutter/appreveal/lib/src/mcp/mcp_router.dart
+++ b/Flutter/appreveal/lib/src/mcp/mcp_router.dart
@@ -43,7 +43,7 @@ class MCPRouter {
         return _response(id, {
           'protocolVersion': '2025-06-18',
           'capabilities': {'tools': {}},
-          'serverInfo': {'name': 'AppReveal', 'version': '0.10.0'},
+          'serverInfo': {'name': 'AppReveal', 'version': '0.10.1'},
         });
 
       case 'tools/list':

--- a/Flutter/appreveal/pubspec.yaml
+++ b/Flutter/appreveal/pubspec.yaml
@@ -1,6 +1,6 @@
 name: appreveal
 description: Debug-only MCP framework for Flutter — gives LLM agents native app control via standard MCP protocol.
-version: 0.10.0
+version: 0.10.1
 homepage: https://github.com/UnlikeOtherAI/AppReveal
 repository: https://github.com/UnlikeOtherAI/AppReveal/tree/main/Flutter/appreveal
 issue_tracker: https://github.com/UnlikeOtherAI/AppReveal/issues

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Full AppReveal integrations share the same core MCP surface across platforms. Fo
 
 ```swift
 // Package.swift
-.package(url: "https://github.com/UnlikeOtherAI/AppReveal.git", from: "0.10.0")
+.package(url: "https://github.com/UnlikeOtherAI/AppReveal.git", from: "0.10.1")
 ```
 
 ```swift
@@ -51,7 +51,7 @@ To opt out of private APIs entirely (even in debug builds), remove the `swiftSet
 
 ```swift
 // Package.swift
-.package(url: "https://github.com/UnlikeOtherAI/AppReveal.git", from: "0.10.0")
+.package(url: "https://github.com/UnlikeOtherAI/AppReveal.git", from: "0.10.1")
 ```
 
 ```swift

--- a/ReactNative/appreveal/android/src/main/kotlin/com/appreveal/mcpserver/MCPRouter.kt
+++ b/ReactNative/appreveal/android/src/main/kotlin/com/appreveal/mcpserver/MCPRouter.kt
@@ -41,7 +41,7 @@ internal object MCPRouter {
                     })
                     add("serverInfo", JsonObject().apply {
                         addProperty("name", "AppReveal")
-                        addProperty("version", "0.10.0")
+                        addProperty("version", "0.10.1")
                     })
                 }
                 MCPResponse.success(request.id, result)

--- a/ReactNative/appreveal/appreveal.podspec
+++ b/ReactNative/appreveal/appreveal.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name             = 'AppReveal'
-  s.version          = '0.10.0'
+  s.version          = '0.10.1'
   s.summary          = 'Debug-only in-app MCP framework for React Native'
   s.description      = <<-DESC
     AppReveal embeds an MCP server inside your React Native app in debug builds,

--- a/ReactNative/appreveal/ios/MCPRouter.swift
+++ b/ReactNative/appreveal/ios/MCPRouter.swift
@@ -60,7 +60,7 @@ final class MCPRouter {
                 ],
                 "serverInfo": [
                     "name": "AppReveal",
-                    "version": "0.10.0"
+                    "version": "0.10.1"
                 ]
             ] as [String: Any]))
 

--- a/ReactNative/appreveal/package.json
+++ b/ReactNative/appreveal/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-appreveal",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "Debug-only in-app MCP framework for React Native",
   "main": "src/index",
   "types": "src/index",

--- a/Windows/AppReveal.Windows/AppReveal.Windows.csproj
+++ b/Windows/AppReveal.Windows/AppReveal.Windows.csproj
@@ -6,7 +6,7 @@
     <AssemblyName>AppReveal.Windows</AssemblyName>
     <RootNamespace>AppReveal.Windows</RootNamespace>
     <PackageId>AppReveal.Windows</PackageId>
-    <Version>0.10.0</Version>
+    <Version>0.10.1</Version>
     <Authors>AppReveal Contributors</Authors>
     <Company>AppReveal Contributors</Company>
     <Title>AppReveal.Windows</Title>
@@ -18,7 +18,7 @@
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
     <PackageReadmeFile>README.md</PackageReadmeFile>
-    <PackageReleaseNotes>Initial Windows native .NET MCP foundation for the AppReveal 0.10.0 release.</PackageReleaseNotes>
+    <PackageReleaseNotes>AppReveal 0.10.1: iOS 26 SwiftUI interaction fixes, Tauri desktop bridge support, and iOS LAN/Bonjour retry hardening.</PackageReleaseNotes>
     <Copyright>Copyright (c) 2026 AppReveal Contributors</Copyright>
   </PropertyGroup>
   <ItemGroup>

--- a/Windows/AppReveal.Windows/README.md
+++ b/Windows/AppReveal.Windows/README.md
@@ -12,7 +12,7 @@ WebView tooling.
 ## Install
 
 ```sh
-dotnet add package AppReveal.Windows --version 0.10.0
+dotnet add package AppReveal.Windows --version 0.10.1
 ```
 
 ## Start in debug builds

--- a/Windows/appreveal-tauri/Cargo.toml
+++ b/Windows/appreveal-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "appreveal-tauri"
-version = "0.10.0"
+version = "0.10.1"
 edition = "2021"
 authors = ["AppReveal Contributors"]
 license = "MIT"

--- a/Windows/appreveal-tauri/README.md
+++ b/Windows/appreveal-tauri/README.md
@@ -13,14 +13,14 @@ metadata.
 ## Install
 
 ```sh
-cargo add appreveal-tauri --version 0.10.0
+cargo add appreveal-tauri --version 0.10.1
 ```
 
 For Tauri integration:
 
 ```toml
 [dependencies]
-appreveal-tauri = { version = "0.10.0", features = ["tauri"] }
+appreveal-tauri = { version = "0.10.1", features = ["tauri"] }
 ```
 
 ## Start in debug builds

--- a/docs/ios.md
+++ b/docs/ios.md
@@ -11,7 +11,7 @@
 ### Swift Package Manager
 
 ```swift
-.package(url: "https://github.com/UnlikeOtherAI/AppReveal.git", from: "0.10.0")
+.package(url: "https://github.com/UnlikeOtherAI/AppReveal.git", from: "0.10.1")
 ```
 
 ## Quick start

--- a/docs/macos.md
+++ b/docs/macos.md
@@ -13,7 +13,7 @@
 Use the same package as iOS. AppReveal ships as a single Swift package with iOS and macOS platform support.
 
 ```swift
-.package(url: "https://github.com/UnlikeOtherAI/AppReveal.git", from: "0.10.0")
+.package(url: "https://github.com/UnlikeOtherAI/AppReveal.git", from: "0.10.1")
 ```
 
 ## Quick start

--- a/iOS/Sources/AppReveal/AppRevealVersion.swift
+++ b/iOS/Sources/AppReveal/AppRevealVersion.swift
@@ -2,5 +2,5 @@
 // Update this constant on every release to match the git tag.
 
 enum AppRevealVersion {
-    static let current = "0.10.0"
+    static let current = "0.10.1"
 }


### PR DESCRIPTION
## Summary
- bump AppReveal package/server metadata and install docs from 0.10.0 to 0.10.1
- align iOS, Android, Flutter, React Native, CLI, Windows .NET, and Tauri package metadata
- update Windows package release notes for the 0.10.1 fix train

## Included fixes since v0.10.0
- Tauri/Rust desktop support and parity bridge (#40)
- iOS 26 SwiftUI TextField direct typing fix (#39)
- iOS 26 SwiftUI ScrollView/LazyVGrid point-tap fix (#38)
- iOS physical-device Bonjour foreground retry hardening (#37)
- previously merged issue fixes #41, #42, #44, and #52

## Verification
- `swift test && swiftlint lint --strict` in `iOS/` — passed
- Android library: `./gradlew :appreveal:testDebugUnitTest :appreveal:ktlintCheck` — passed
- Android Emulator `emulator-5554`: `example/Android/verify-compose-mcp.sh` — passed
- Tauri/Rust: `cargo test --manifest-path Windows/appreveal-tauri/Cargo.toml -- --test-threads=1` — passed
- Tauri/Rust with feature: `cargo test --manifest-path Windows/appreveal-tauri/Cargo.toml --features tauri -- --test-threads=1` — passed
- Tauri package dry run: `cargo package --manifest-path Windows/appreveal-tauri/Cargo.toml --allow-dirty --no-verify` — passed
- CLI: `pnpm install --frozen-lockfile && pnpm lint` — passed
- React Native: `pnpm install --frozen-lockfile && pnpm lint` — passed
- Flutter: `flutter pub get && flutter analyze --fatal-warnings && flutter test` — passed
- `git diff --check` — passed

## Local limitation
- `dotnet build Windows/AppReveal.Windows/AppReveal.Windows.csproj` cannot run on this macOS SDK because `Microsoft.WindowsDesktop.App.WindowsForms` is unavailable locally; the Windows GitHub Actions job covers this build.
